### PR TITLE
Add local Chrome profile import to the Kernel CLI

### DIFF
--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -1,0 +1,342 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	localbrowser "github.com/kernel/cli/internal/browserimport"
+	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/interactive"
+	"github.com/kernel/cli/pkg/util"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+type ProfilesImportLocalInput struct {
+	BrowserProfile string
+	ProfileName    string
+	Sites          []string
+	Count          int
+	Days           int
+	SkipConfirm    bool
+	Output         string
+	ProjectID      string
+	Version        string
+}
+
+type ProfilesImportLocalCmd struct {
+	prompter interactive.Prompter
+	homeDir  func() (string, error)
+	now      func() time.Time
+}
+
+func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
+	if err := validateJSONOutput(in.Output); err != nil {
+		return err
+	}
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("local browser import currently supports macOS")
+	}
+	if in.Count < 5 || in.Count > 10 {
+		return fmt.Errorf("--count must be between 5 and 10")
+	}
+	if in.Days < 1 || in.Days > 90 {
+		return fmt.Errorf("--days must be between 1 and 90")
+	}
+	if len(in.Sites) > 10 {
+		return fmt.Errorf("select at most 10 sites")
+	}
+	if c.homeDir == nil {
+		c.homeDir = os.UserHomeDir
+	}
+	if c.now == nil {
+		c.now = time.Now
+	}
+
+	home, err := c.homeDir()
+	if err != nil {
+		return err
+	}
+	humanOutput := in.Output != "json"
+	if humanOutput {
+		pterm.Info.Println("Looking for local Chrome profiles...")
+	}
+	profiles, err := localbrowser.DiscoverMacOSProfiles(home)
+	if err != nil {
+		return err
+	}
+	if len(profiles) == 0 {
+		return fmt.Errorf("no Google Chrome or Helium profiles were found")
+	}
+	profile, err := c.chooseProfile(profiles, in.BrowserProfile)
+	if err != nil {
+		return err
+	}
+
+	if humanOutput {
+		pterm.Success.Printf("Found %s\n", profile.DisplayName())
+	}
+	recent, err := localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 10)
+	if err != nil {
+		return err
+	}
+	if len(recent) == 0 && len(in.Sites) == 0 {
+		return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
+	}
+	selected, err := c.chooseSites(recent, in.Sites, in.Count, in.SkipConfirm)
+	if err != nil {
+		return err
+	}
+	if len(selected) == 0 {
+		return fmt.Errorf("select at least one website")
+	}
+
+	if humanOutput {
+		pterm.Info.Printf("Reading cookies for %d selected websites...\n", len(selected))
+	}
+	cookies, err := localbrowser.ExportCookies(ctx, profile, selected)
+	if err != nil {
+		return err
+	}
+	if len(cookies) == 0 {
+		return fmt.Errorf("the selected websites have no importable cookies")
+	}
+	selectedSites := selectedSiteDetails(recent, selected)
+	selectedSites = localbrowser.CountCookiesBySite(cookies, selectedSites)
+	if humanOutput {
+		printSelectedSites(selectedSites)
+	}
+
+	targetName := in.ProfileName
+	if targetName == "" {
+		targetName = defaultImportedProfileName(profile)
+	}
+	if !in.SkipConfirm {
+		ok, err := c.prompter.Confirm("import browser data", fmt.Sprintf("Import %d cookies into Kernel profile %q?", len(cookies), targetName))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			pterm.Info.Println("Import cancelled")
+			return nil
+		}
+	}
+
+	version := in.Version
+	if version == "" {
+		version = "dev"
+	}
+	bundle, err := localbrowser.BuildCookieBundle(ctx, profile, targetName, version, cookies)
+	if err != nil {
+		return err
+	}
+	token, err := auth.BearerToken(ctx)
+	if err != nil {
+		return err
+	}
+	client, err := localbrowser.NewClient(util.GetBaseURL(), token, in.ProjectID)
+	if err != nil {
+		return err
+	}
+	if humanOutput {
+		pterm.Info.Println("Creating Kernel profile...")
+	}
+	created, err := client.Create(ctx)
+	if err != nil {
+		return err
+	}
+	inventory := localbrowser.Inventory{Sources: []localbrowser.Source{{
+		ID: profile.ID, Kind: "browser", Name: profile.DisplayName(), Browser: profile.Browser.ID,
+		DataTypes: []string{"cookies"}, ItemCounts: map[string]int{"cookies": len(cookies)},
+	}}}
+	if _, err := client.SubmitInventory(ctx, created.ID, created.HelperToken, inventory); err != nil {
+		return err
+	}
+	selection := localbrowser.Selection{Profiles: []localbrowser.ProfileSelection{{SourceID: profile.ID, TargetName: targetName, Categories: []string{"cookies"}}}, CredentialSources: make([]string, 0)}
+	if _, err := client.SubmitSelection(ctx, created.ID, selection); err != nil {
+		return err
+	}
+	if _, err := client.Upload(ctx, created.ID, created.HelperToken, bundle); err != nil {
+		return err
+	}
+	if humanOutput {
+		pterm.Info.Println("Saving browser state to Kernel...")
+	}
+	status, err := client.Wait(ctx, created.ID, 2*time.Second)
+	if err != nil {
+		return err
+	}
+	if status.Applied == nil || len(status.Applied.Profiles) == 0 {
+		return fmt.Errorf("browser import completed without a profile")
+	}
+	profileID := status.Applied.Profiles[0].ProfileID
+	if in.Output == "json" {
+		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies)}, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+	pterm.Success.Printf("%s is ready for agents\n", targetName)
+	pterm.Printf("Imported %d cookies from %d websites\n", len(cookies), len(selected))
+	pterm.Printf("Next: kernel browsers create --profile %s\n", targetName)
+	return nil
+}
+
+func (c ProfilesImportLocalCmd) chooseProfile(profiles []localbrowser.Profile, requested string) (localbrowser.Profile, error) {
+	if requested != "" {
+		for _, profile := range profiles {
+			if profile.ID == requested || strings.EqualFold(profile.DisplayName(), requested) {
+				return profile, nil
+			}
+		}
+		return localbrowser.Profile{}, fmt.Errorf("browser profile %q was not found", requested)
+	}
+	if len(profiles) == 1 {
+		return profiles[0], nil
+	}
+	options := make([]string, 0, len(profiles))
+	for _, profile := range profiles {
+		options = append(options, profile.DisplayName())
+	}
+	chosen, err := c.prompter.Select("browser profile", "pass --browser-profile", "Choose the local browser profile to import", options)
+	if err != nil {
+		return localbrowser.Profile{}, err
+	}
+	for _, profile := range profiles {
+		if profile.DisplayName() == chosen {
+			return profile, nil
+		}
+	}
+	return localbrowser.Profile{}, fmt.Errorf("selected browser profile is unavailable")
+}
+
+func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requested []string, count int, skipPrompt bool) ([]string, error) {
+	if len(requested) > 0 {
+		return normalizeSites(requested), nil
+	}
+	if len(recent) < count {
+		count = len(recent)
+	}
+	defaults := make([]string, 0, count)
+	for _, site := range recent[:count] {
+		defaults = append(defaults, site.Domain)
+	}
+	if skipPrompt {
+		return defaults, nil
+	}
+	labels := make([]string, 0, len(recent))
+	byLabel := make(map[string]string, len(recent))
+	defaultLabels := make([]string, 0, count)
+	for index, site := range recent {
+		label := fmt.Sprintf("%-32s %d visits", site.Domain, site.Visits)
+		labels = append(labels, label)
+		byLabel[label] = site.Domain
+		if index < count {
+			defaultLabels = append(defaultLabels, label)
+		}
+	}
+	chosen, err := c.prompter.MultiSelect("websites", "pass --sites or --yes", "Choose websites to bring to Kernel", labels, defaultLabels)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(chosen))
+	for _, label := range chosen {
+		result = append(result, byLabel[label])
+	}
+	return result, nil
+}
+
+func normalizeSites(values []string) []string {
+	seen := make(map[string]struct{})
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			domain := strings.TrimSpace(strings.ToLower(part))
+			if domain == "" {
+				continue
+			}
+			if _, ok := seen[domain]; ok {
+				continue
+			}
+			seen[domain] = struct{}{}
+			result = append(result, domain)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func selectedSiteDetails(recent []localbrowser.Site, selected []string) []localbrowser.Site {
+	byDomain := make(map[string]localbrowser.Site, len(recent))
+	for _, site := range recent {
+		byDomain[site.Domain] = site
+	}
+	result := make([]localbrowser.Site, 0, len(selected))
+	for _, domain := range selected {
+		site := byDomain[domain]
+		site.Domain = domain
+		result = append(result, site)
+	}
+	return result
+}
+
+func printSelectedSites(sites []localbrowser.Site) {
+	rows := pterm.TableData{{"Website", "Recent visits", "Cookies"}}
+	for _, site := range sites {
+		rows = append(rows, []string{site.Domain, fmt.Sprintf("%d", site.Visits), fmt.Sprintf("%d", site.CookieCount)})
+	}
+	PrintTableNoPad(rows, true)
+}
+
+func defaultImportedProfileName(profile localbrowser.Profile) string {
+	name := strings.ToLower(profile.Browser.ID + "-" + profile.Name)
+	name = strings.Trim(profileIDNameCharacters.ReplaceAllString(name, "-"), "-")
+	if name == "" {
+		return "imported-browser"
+	}
+	return name
+}
+
+var profileIDNameCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+var profilesImportLocalCmd = &cobra.Command{
+	Use:   "import-local",
+	Short: "Import recent websites from a local browser",
+	Long:  "Import selected cookies from a local Google Chrome or Helium profile on macOS into a Kernel browser profile.",
+	Args:  cobra.NoArgs,
+	RunE:  runProfilesImportLocal,
+}
+
+func init() {
+	profilesCmd.AddCommand(profilesImportLocalCmd)
+	profilesImportLocalCmd.Flags().String("browser-profile", "", "Local browser profile ID or name")
+	profilesImportLocalCmd.Flags().String("profile-name", "", "Kernel profile name")
+	profilesImportLocalCmd.Flags().StringSlice("sites", nil, "Website domains to import (up to 10)")
+	profilesImportLocalCmd.Flags().Int("count", 5, "Number of recent websites selected by default (5-10)")
+	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
+	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
+	addJSONOutputFlag(profilesImportLocalCmd)
+}
+
+func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
+	browserProfile, _ := cmd.Flags().GetString("browser-profile")
+	profileName, _ := cmd.Flags().GetString("profile-name")
+	sites, _ := cmd.Flags().GetStringSlice("sites")
+	count, _ := cmd.Flags().GetInt("count")
+	days, _ := cmd.Flags().GetInt("days")
+	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	output, _ := cmd.Flags().GetString("output")
+	project, _ := cmd.Flags().GetString("project")
+	project = resolveProjectSelection(project)
+	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter()}
+	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version})
+}

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -181,7 +181,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if err != nil {
 		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)
 	}
-	selection := localbrowser.Selection{Profiles: []localbrowser.ProfileSelection{{SourceID: profile.ID, TargetName: targetName, Categories: []string{"cookies"}}}, CredentialSources: make([]string, 0)}
+	selection := localbrowser.Selection{Profiles: []localbrowser.ProfileSelection{{SourceID: profile.ID, TargetName: targetName, Categories: []string{"cookies"}}}}
 	status, err = client.SubmitSelection(ctx, created.ID, selection)
 	if err != nil {
 		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -29,6 +29,7 @@ type ProfilesImportLocalInput struct {
 	Output         string
 	ProjectID      string
 	Version        string
+	WaitTimeout    time.Duration
 }
 
 type ProfilesImportLocalCmd struct {
@@ -38,6 +39,8 @@ type ProfilesImportLocalCmd struct {
 }
 
 func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
+	startedAt := time.Now()
+	timings := make(map[string]time.Duration)
 	if err := validateJSONOutput(in.Output); err != nil {
 		return err
 	}
@@ -52,6 +55,9 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	}
 	if len(in.Sites) > 10 {
 		return fmt.Errorf("select at most 10 sites")
+	}
+	if in.WaitTimeout <= 0 {
+		in.WaitTimeout = 30 * time.Minute
 	}
 	if c.homeDir == nil {
 		c.homeDir = os.UserHomeDir
@@ -68,7 +74,9 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if humanOutput {
 		pterm.Info.Println("Looking for local Chrome profiles...")
 	}
+	phaseStarted := time.Now()
 	profiles, err := localbrowser.DiscoverMacOSProfiles(home)
+	timings["discovery"] = time.Since(phaseStarted)
 	if err != nil {
 		return err
 	}
@@ -83,12 +91,24 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if humanOutput {
 		pterm.Success.Printf("Found %s\n", profile.DisplayName())
 	}
-	recent, err := localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 10)
-	if err != nil {
-		return err
+	targetName := in.ProfileName
+	if targetName == "" {
+		targetName = defaultImportedProfileName(profile)
 	}
-	if len(recent) == 0 && len(in.Sites) == 0 {
-		return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
+	if targetName == "" || len(targetName) > 255 || profileIDNameCharacters.MatchString(targetName) || cuidLikeProfileName.MatchString(targetName) {
+		return fmt.Errorf("profile name must be 1-255 letters, numbers, dots, underscores, or hyphens and cannot be a cuid-like string")
+	}
+	recent := make([]localbrowser.Site, 0)
+	if len(in.Sites) == 0 {
+		phaseStarted = time.Now()
+		recent, err = localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 10)
+		timings["history"] = time.Since(phaseStarted)
+		if err != nil {
+			return err
+		}
+		if len(recent) == 0 {
+			return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
+		}
 	}
 	selected, err := c.chooseSites(recent, in.Sites, in.Count, in.SkipConfirm)
 	if err != nil {
@@ -101,7 +121,9 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if humanOutput {
 		pterm.Info.Printf("Reading cookies for %d selected websites...\n", len(selected))
 	}
+	phaseStarted = time.Now()
 	cookies, err := localbrowser.ExportCookies(ctx, profile, selected)
+	timings["cookies"] = time.Since(phaseStarted)
 	if err != nil {
 		return err
 	}
@@ -114,10 +136,6 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		printSelectedSites(selectedSites)
 	}
 
-	targetName := in.ProfileName
-	if targetName == "" {
-		targetName = defaultImportedProfileName(profile)
-	}
 	if !in.SkipConfirm {
 		ok, err := c.prompter.Confirm("import browser data", fmt.Sprintf("Import %d cookies into Kernel profile %q?", len(cookies), targetName))
 		if err != nil {
@@ -133,7 +151,9 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if version == "" {
 		version = "dev"
 	}
+	phaseStarted = time.Now()
 	bundle, err := localbrowser.BuildCookieBundle(ctx, profile, targetName, version, cookies)
+	timings["bundle"] = time.Since(phaseStarted)
 	if err != nil {
 		return err
 	}
@@ -148,6 +168,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if humanOutput {
 		pterm.Info.Println("Creating Kernel profile...")
 	}
+	phaseStarted = time.Now()
 	created, err := client.Create(ctx)
 	if err != nil {
 		return err
@@ -156,29 +177,35 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		ID: profile.ID, Kind: "browser", Name: profile.DisplayName(), Browser: profile.Browser.ID,
 		DataTypes: []string{"cookies"}, ItemCounts: map[string]int{"cookies": len(cookies)},
 	}}}
-	if _, err := client.SubmitInventory(ctx, created.ID, created.HelperToken, inventory); err != nil {
-		return err
+	status, err := client.SubmitInventory(ctx, created.ID, created.HelperToken, inventory)
+	if err != nil {
+		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)
 	}
 	selection := localbrowser.Selection{Profiles: []localbrowser.ProfileSelection{{SourceID: profile.ID, TargetName: targetName, Categories: []string{"cookies"}}}, CredentialSources: make([]string, 0)}
-	if _, err := client.SubmitSelection(ctx, created.ID, selection); err != nil {
-		return err
+	status, err = client.SubmitSelection(ctx, created.ID, selection)
+	if err != nil {
+		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)
 	}
-	if _, err := client.Upload(ctx, created.ID, created.HelperToken, bundle); err != nil {
-		return err
+	status, err = client.Upload(ctx, created.ID, created.HelperToken, bundle)
+	if err != nil {
+		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)
 	}
 	if humanOutput {
 		pterm.Info.Println("Saving browser state to Kernel...")
 	}
-	status, err := client.Wait(ctx, created.ID, 2*time.Second)
+	waitCtx, cancelWait := context.WithTimeout(ctx, in.WaitTimeout)
+	defer cancelWait()
+	status, err = client.Wait(waitCtx, created.ID, 2*time.Second)
+	timings["upload_and_apply"] = time.Since(phaseStarted)
 	if err != nil {
-		return err
+		return fmt.Errorf("browser import %s did not complete: %w; check it with: kernel profiles import-status %s", created.ID, err, created.ID)
 	}
 	if status.Applied == nil || len(status.Applied.Profiles) == 0 {
 		return fmt.Errorf("browser import completed without a profile")
 	}
 	profileID := status.Applied.Profiles[0].ProfileID
 	if in.Output == "json" {
-		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies)}, "", "  ")
+		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies), "duration_ms": time.Since(startedAt).Milliseconds(), "timings_ms": durationMilliseconds(timings)}, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -187,16 +214,83 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	}
 	pterm.Success.Printf("%s is ready for agents\n", targetName)
 	pterm.Printf("Imported %d cookies from %d websites\n", len(cookies), len(selected))
+	pterm.Printf("Completed in %s (local read %s, upload and apply %s)\n", time.Since(startedAt).Round(time.Millisecond), (timings["history"] + timings["cookies"]).Round(time.Millisecond), timings["upload_and_apply"].Round(time.Millisecond))
 	pterm.Printf("Next: kernel browsers create --profile %s\n", targetName)
+	return nil
+}
+
+func browserImportProgressError(importID, phase string, elapsed time.Duration, err error) error {
+	if phase == "" {
+		phase = "unknown"
+	}
+	return fmt.Errorf("browser import %s stopped after %s in phase %s: %w; check it with: kernel profiles import-status %s", importID, elapsed.Round(time.Millisecond), phase, err, importID)
+}
+
+func durationMilliseconds(values map[string]time.Duration) map[string]int64 {
+	result := make(map[string]int64, len(values))
+	for name, duration := range values {
+		result[name] = duration.Milliseconds()
+	}
+	return result
+}
+
+func runProfilesImportStatus(cmd *cobra.Command, args []string) error {
+	output, _ := cmd.Flags().GetString("output")
+	if err := validateJSONOutput(output); err != nil {
+		return err
+	}
+	token, err := auth.BearerToken(cmd.Context())
+	if err != nil {
+		return err
+	}
+	project, _ := cmd.Flags().GetString("project")
+	client, err := localbrowser.NewClient(util.GetBaseURL(), token, resolveProjectSelection(project))
+	if err != nil {
+		return err
+	}
+	status, err := client.Status(cmd.Context(), args[0])
+	if err != nil {
+		return err
+	}
+	if output == "json" {
+		data, err := json.MarshalIndent(status, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		if status.Phase == "failed" {
+			return fmt.Errorf("browser import %s failed", status.ID)
+		}
+		return nil
+	}
+	pterm.Info.Printf("Browser import %s: %s\n", status.ID, status.Phase)
+	if status.Applied != nil {
+		for _, applied := range status.Applied.Profiles {
+			pterm.Success.Printf("Profile %s is ready (%s)\n", applied.TargetName, applied.ProfileID)
+		}
+		if status.Applied.Failure != nil {
+			return fmt.Errorf("%s: %s", status.Applied.Failure.Stage, status.Applied.Failure.Message)
+		}
+	}
+	if status.Phase == "failed" {
+		return fmt.Errorf("browser import %s failed", status.ID)
+	}
 	return nil
 }
 
 func (c ProfilesImportLocalCmd) chooseProfile(profiles []localbrowser.Profile, requested string) (localbrowser.Profile, error) {
 	if requested != "" {
+		matches := make([]localbrowser.Profile, 0, 1)
 		for _, profile := range profiles {
 			if profile.ID == requested || strings.EqualFold(profile.DisplayName(), requested) {
-				return profile, nil
+				matches = append(matches, profile)
 			}
+		}
+		if len(matches) == 1 {
+			return matches[0], nil
+		}
+		if len(matches) > 1 {
+			return localbrowser.Profile{}, fmt.Errorf("browser profile %q is ambiguous; use its profile ID", requested)
 		}
 		return localbrowser.Profile{}, fmt.Errorf("browser profile %q was not found", requested)
 	}
@@ -204,24 +298,28 @@ func (c ProfilesImportLocalCmd) chooseProfile(profiles []localbrowser.Profile, r
 		return profiles[0], nil
 	}
 	options := make([]string, 0, len(profiles))
+	byOption := make(map[string]localbrowser.Profile, len(profiles))
 	for _, profile := range profiles {
-		options = append(options, profile.DisplayName())
+		label := profile.DisplayName()
+		if profile.Directory != "" {
+			label += " (" + profile.Directory + ")"
+		}
+		options = append(options, label)
+		byOption[label] = profile
 	}
 	chosen, err := c.prompter.Select("browser profile", "pass --browser-profile", "Choose the local browser profile to import", options)
 	if err != nil {
 		return localbrowser.Profile{}, err
 	}
-	for _, profile := range profiles {
-		if profile.DisplayName() == chosen {
-			return profile, nil
-		}
+	if profile, ok := byOption[chosen]; ok {
+		return profile, nil
 	}
 	return localbrowser.Profile{}, fmt.Errorf("selected browser profile is unavailable")
 }
 
 func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requested []string, count int, skipPrompt bool) ([]string, error) {
 	if len(requested) > 0 {
-		return normalizeSites(requested), nil
+		return normalizeSites(requested)
 	}
 	if len(recent) < count {
 		count = len(recent)
@@ -255,12 +353,18 @@ func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requeste
 	return result, nil
 }
 
-func normalizeSites(values []string) []string {
+func normalizeSites(values []string) ([]string, error) {
 	seen := make(map[string]struct{})
 	result := make([]string, 0, len(values))
 	for _, value := range values {
 		for _, part := range strings.Split(value, ",") {
-			domain := strings.TrimSpace(strings.ToLower(part))
+			if strings.TrimSpace(part) == "" {
+				continue
+			}
+			domain, err := localbrowser.CanonicalSite(part)
+			if err != nil {
+				return nil, err
+			}
 			if domain == "" {
 				continue
 			}
@@ -272,7 +376,7 @@ func normalizeSites(values []string) []string {
 		}
 	}
 	sort.Strings(result)
-	return result
+	return result, nil
 }
 
 func selectedSiteDetails(recent []localbrowser.Site, selected []string) []localbrowser.Site {
@@ -307,6 +411,7 @@ func defaultImportedProfileName(profile localbrowser.Profile) string {
 }
 
 var profileIDNameCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+var cuidLikeProfileName = regexp.MustCompile(`^[a-z0-9]{24}$`)
 
 var profilesImportLocalCmd = &cobra.Command{
 	Use:   "import-local",
@@ -316,15 +421,25 @@ var profilesImportLocalCmd = &cobra.Command{
 	RunE:  runProfilesImportLocal,
 }
 
+var profilesImportStatusCmd = &cobra.Command{
+	Use:   "import-status <import-id>",
+	Short: "Check a local browser import",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProfilesImportStatus,
+}
+
 func init() {
 	profilesCmd.AddCommand(profilesImportLocalCmd)
+	profilesCmd.AddCommand(profilesImportStatusCmd)
 	profilesImportLocalCmd.Flags().String("browser-profile", "", "Local browser profile ID or name")
 	profilesImportLocalCmd.Flags().String("profile-name", "", "Kernel profile name")
 	profilesImportLocalCmd.Flags().StringSlice("sites", nil, "Website domains to import (up to 10)")
 	profilesImportLocalCmd.Flags().Int("count", 5, "Number of recent websites selected by default (5-10)")
 	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
+	profilesImportLocalCmd.Flags().Duration("wait-timeout", 30*time.Minute, "Maximum time to wait for the import to complete")
 	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
 	addJSONOutputFlag(profilesImportLocalCmd)
+	addJSONOutputFlag(profilesImportStatusCmd)
 }
 
 func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
@@ -333,10 +448,11 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	sites, _ := cmd.Flags().GetStringSlice("sites")
 	count, _ := cmd.Flags().GetInt("count")
 	days, _ := cmd.Flags().GetInt("days")
+	waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
 	output, _ := cmd.Flags().GetString("output")
 	project, _ := cmd.Flags().GetString("project")
 	project = resolveProjectSelection(project)
 	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter()}
-	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version})
+	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version, WaitTimeout: waitTimeout})
 }

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"testing"
+
+	localbrowser "github.com/kernel/cli/internal/browserimport"
+	"github.com/kernel/cli/pkg/interactive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSitesFlattensDeduplicatesAndSorts(t *testing.T) {
+	assert.Equal(t, []string{"example.com", "github.com"}, normalizeSites([]string{" GitHub.com,example.com ", "github.com"}))
+}
+
+func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
+	selected, err := command.chooseSites(nil, []string{"github.com"}, 5, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"github.com"}, selected)
+}
+
+func TestChooseSitesUsesTopFiveWithYes(t *testing.T) {
+	recent := make([]localbrowser.Site, 0, 7)
+	for _, domain := range []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"} {
+		recent = append(recent, localbrowser.Site{Domain: domain})
+	}
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
+	selected, err := command.chooseSites(recent, nil, 5, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com"}, selected)
+}
+
+func TestChooseSitesFailsFastWithoutTTYOrFlags(t *testing.T) {
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
+	_, err := command.chooseSites([]localbrowser.Site{{Domain: "example.com"}}, nil, 5, false)
+	var promptError *interactive.PromptError
+	require.ErrorAs(t, err, &promptError)
+	assert.Contains(t, promptError.Error(), "pass --sites or --yes")
+}
+
+func TestDefaultImportedProfileName(t *testing.T) {
+	profile := localbrowser.Profile{Name: "Ilyaas Personal", Browser: localbrowser.Browser{ID: "chrome"}}
+	assert.Equal(t, "chrome-ilyaas-personal", defaultImportedProfileName(profile))
+}
+
+func TestProfilesImportLocalRejectsUnsupportedOutputBeforeDiscovery(t *testing.T) {
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
+	err := command.Run(t.Context(), ProfilesImportLocalInput{Output: "yaml", Count: 5, Days: 30})
+	assert.EqualError(t, err, `unsupported --output value "yaml"; use "json" or omit --output for human-readable output`)
+}

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestNormalizeSitesFlattensDeduplicatesAndSorts(t *testing.T) {
-	assert.Equal(t, []string{"example.com", "github.com"}, normalizeSites([]string{" GitHub.com,example.com ", "github.com"}))
+	sites, err := normalizeSites([]string{" GitHub.com,example.com ", "github.com"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"example.com", "github.com"}, sites)
 }
 
 func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {
@@ -48,4 +50,21 @@ func TestProfilesImportLocalRejectsUnsupportedOutputBeforeDiscovery(t *testing.T
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
 	err := command.Run(t.Context(), ProfilesImportLocalInput{Output: "yaml", Count: 5, Days: 30})
 	assert.EqualError(t, err, `unsupported --output value "yaml"; use "json" or omit --output for human-readable output`)
+}
+
+func TestProfilesImportStatusRejectsUnsupportedOutputBeforeAuthentication(t *testing.T) {
+	profilesImportStatusCmd.Flags().Set("output", "yaml")
+	t.Cleanup(func() { _ = profilesImportStatusCmd.Flags().Set("output", "") })
+	err := runProfilesImportStatus(profilesImportStatusCmd, []string{"imp_test"})
+	assert.EqualError(t, err, `unsupported --output value "yaml"; use "json" or omit --output for human-readable output`)
+}
+
+func TestChooseProfileRejectsDuplicateFriendlyName(t *testing.T) {
+	profiles := []localbrowser.Profile{
+		{ID: "one", Name: "Personal", Browser: localbrowser.Browser{Name: "Google Chrome"}},
+		{ID: "two", Name: "Personal", Browser: localbrowser.Browser{Name: "Google Chrome"}},
+	}
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
+	_, err := command.chooseProfile(profiles, "Google Chrome / Personal")
+	assert.EqualError(t, err, `browser profile "Google Chrome / Personal" is ambiguous; use its profile ID`)
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/crypto v0.52.0
+	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/browserimport/bundle.go
+++ b/internal/browserimport/bundle.go
@@ -1,0 +1,106 @@
+package browserimport
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const maxBundleBytes = 128 << 20
+
+type Manifest struct {
+	Version  int             `json:"version"`
+	Source   BundleSource    `json:"source"`
+	Profiles []BundleProfile `json:"profiles,omitempty"`
+}
+
+type BundleSource struct {
+	OS            string `json:"os"`
+	HelperVersion string `json:"helper_version"`
+}
+
+type BundleProfile struct {
+	ID         string       `json:"id"`
+	Browser    string       `json:"browser"`
+	SourceName string       `json:"source_name"`
+	TargetName string       `json:"target_name"`
+	Files      ProfileFiles `json:"files"`
+}
+
+type ProfileFiles struct {
+	Cookies string `json:"cookies,omitempty"`
+}
+
+func BuildCookieBundle(ctx context.Context, profile Profile, targetName, version string, cookies []Cookie) ([]byte, error) {
+	if len(cookies) == 0 {
+		return nil, fmt.Errorf("no cookies were selected")
+	}
+	cookiePath := "profiles/" + profile.ID + "/cookies.jsonl"
+	manifest := Manifest{
+		Version: BundleVersion,
+		Source:  BundleSource{OS: "macos", HelperVersion: version},
+		Profiles: []BundleProfile{{
+			ID: profile.ID, Browser: profile.Browser.ID, SourceName: profile.DisplayName(), TargetName: targetName,
+			Files: ProfileFiles{Cookies: cookiePath},
+		}},
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("encode import manifest: %w", err)
+	}
+	var cookieData bytes.Buffer
+	encoder := json.NewEncoder(&cookieData)
+	for _, cookie := range cookies {
+		if err := encoder.Encode(cookie); err != nil {
+			return nil, fmt.Errorf("encode browser cookie: %w", err)
+		}
+	}
+	return encodeBundle(ctx, manifestData, map[string][]byte{cookiePath: cookieData.Bytes()})
+}
+
+func encodeBundle(ctx context.Context, manifest []byte, files map[string][]byte) ([]byte, error) {
+	var output bytes.Buffer
+	zstdWriter, err := zstd.NewWriter(&output, zstd.WithEncoderConcurrency(1))
+	if err != nil {
+		return nil, err
+	}
+	tarWriter := tar.NewWriter(zstdWriter)
+	write := func(name string, data []byte) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o600, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			return err
+		}
+		_, err := tarWriter.Write(data)
+		return err
+	}
+	if err := write("manifest.json", manifest); err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		if err := write(path, files[path]); err != nil {
+			return nil, err
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+	if err := zstdWriter.Close(); err != nil {
+		return nil, err
+	}
+	if output.Len() > maxBundleBytes {
+		return nil, fmt.Errorf("selected browser data exceeds the 128 MiB import limit")
+	}
+	return output.Bytes(), nil
+}

--- a/internal/browserimport/bundle_test.go
+++ b/internal/browserimport/bundle_test.go
@@ -1,0 +1,46 @@
+package browserimport
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCookieBundleMatchesServerContract(t *testing.T) {
+	profile := Profile{ID: "chrome-default-1234", Name: "Personal", Browser: Browser{ID: "chrome", Name: "Google Chrome"}}
+	bundle, err := BuildCookieBundle(context.Background(), profile, "my-browser", "test", []Cookie{{Domain: ".example.com", Path: "/", Name: "session", Value: "secret", Secure: true}})
+	require.NoError(t, err)
+
+	decoder, err := zstd.NewReader(bytes.NewReader(bundle))
+	require.NoError(t, err)
+	defer decoder.Close()
+	reader := tar.NewReader(decoder)
+	header, err := reader.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "manifest.json", header.Name)
+	manifestData, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	var manifest Manifest
+	require.NoError(t, json.Unmarshal(manifestData, &manifest))
+	assert.Equal(t, BundleVersion, manifest.Version)
+	assert.Equal(t, "my-browser", manifest.Profiles[0].TargetName)
+
+	header, err = reader.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "profiles/chrome-default-1234/cookies.jsonl", header.Name)
+	var cookie Cookie
+	require.NoError(t, json.NewDecoder(reader).Decode(&cookie))
+	assert.Equal(t, "secret", cookie.Value)
+}
+
+func TestBuildCookieBundleRequiresCookies(t *testing.T) {
+	_, err := BuildCookieBundle(context.Background(), Profile{}, "profile", "test", nil)
+	assert.EqualError(t, err, "no cookies were selected")
+}

--- a/internal/browserimport/chromium.go
+++ b/internal/browserimport/chromium.go
@@ -28,6 +28,7 @@ import (
 const (
 	maxDocumentBytes = 16 << 20
 	maxSQLiteOutput  = 64 << 20
+	maxSQLiteBytes   = 2 << 30
 )
 
 var profileIDCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
@@ -92,10 +93,10 @@ func discoverProfiles(browser Browser) ([]Profile, error) {
 	profiles := make([]Profile, 0, len(directories))
 	for _, directory := range directories {
 		path := filepath.Join(browser.Root, directory)
-		if _, err := os.Stat(filepath.Join(path, "History")); err != nil {
+		if !fileExists(filepath.Join(path, "History")) && !fileExists(filepath.Join(path, "Network/Cookies")) && !fileExists(filepath.Join(path, "Cookies")) {
 			continue
 		}
-		profiles = append(profiles, Profile{ID: profileID(browser.ID, directory), Name: names[directory], Browser: browser, Path: path})
+		profiles = append(profiles, Profile{ID: profileID(browser.ID, directory), Name: names[directory], Browser: browser, Path: path, Directory: directory})
 	}
 	return profiles, nil
 }
@@ -113,7 +114,7 @@ func RecentSites(ctx context.Context, profile Profile, since time.Time, limit in
 	const chromeEpochMicros = int64(11_644_473_600_000_000)
 	cutoff := since.UnixMicro() + chromeEpochMicros
 	query := fmt.Sprintf(`SELECT u.url, COUNT(*) AS visits, MAX(v.visit_time) AS last_visit FROM visits v JOIN urls u ON u.id = v.url WHERE v.visit_time >= %d AND (u.url LIKE 'http://%%' OR u.url LIKE 'https://%%') GROUP BY u.url ORDER BY visits DESC, last_visit DESC LIMIT 10000`, cutoff)
-	data, err := sqliteJSON(ctx, filepath.Join(profile.Path, "History"), query)
+	data, err := sqliteSnapshotJSON(ctx, filepath.Join(profile.Path, "History"), query)
 	if err != nil {
 		return nil, fmt.Errorf("read recent browser history: %w", err)
 	}
@@ -134,7 +135,10 @@ func RecentSites(ctx context.Context, profile Profile, since time.Time, limit in
 		if err != nil || parsed.Hostname() == "" {
 			continue
 		}
-		domain := registrableDomain(parsed.Hostname())
+		domain, err := CanonicalSite(parsed.Hostname())
+		if err != nil {
+			continue
+		}
 		site := byDomain[domain]
 		site.Domain = domain
 		site.Visits += row.Visits
@@ -161,11 +165,29 @@ func RecentSites(ctx context.Context, profile Profile, since time.Time, limit in
 }
 
 func ExportCookies(ctx context.Context, profile Profile, selectedSites []string) ([]Cookie, error) {
+	canonicalSites := make([]string, 0, len(selectedSites))
+	seenSites := make(map[string]struct{}, len(selectedSites))
+	for _, selected := range selectedSites {
+		site, err := CanonicalSite(selected)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := seenSites[site]; !exists {
+			seenSites[site] = struct{}{}
+			canonicalSites = append(canonicalSites, site)
+		}
+	}
+	selectedSites = canonicalSites
 	path := filepath.Join(profile.Path, "Network/Cookies")
 	if _, err := os.Stat(path); err != nil {
 		path = filepath.Join(profile.Path, "Cookies")
 	}
-	columnsData, err := sqliteJSON(ctx, path, `SELECT name FROM pragma_table_info('cookies')`)
+	snapshot, cleanup, err := sqliteSnapshot(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot cookie database: %w", err)
+	}
+	defer cleanup()
+	columnsData, err := sqliteJSON(ctx, snapshot, `SELECT name FROM pragma_table_info('cookies')`)
 	if err != nil {
 		return nil, fmt.Errorf("inspect cookie database: %w", err)
 	}
@@ -175,19 +197,19 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 	if err := json.Unmarshal(columnsData, &columns); err != nil {
 		return nil, fmt.Errorf("decode cookie schema: %w", err)
 	}
-	partitionClause := ""
+	partitionPredicates := []string{"(expires_utc = 0 OR expires_utc > " + fmt.Sprintf("%d", time.Now().UnixMicro()+11_644_473_600_000_000) + ")"}
 	for _, column := range columns {
 		switch column.Name {
 		case "top_frame_site_key":
-			partitionClause = " WHERE top_frame_site_key = ''"
+			partitionPredicates = append(partitionPredicates, "top_frame_site_key = ''")
 		case "is_partitioned":
-			if partitionClause == "" {
-				partitionClause = " WHERE is_partitioned = 0"
-			}
+			partitionPredicates = append(partitionPredicates, "is_partitioned = 0")
 		}
 	}
-	query := `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + partitionClause + ` ORDER BY host_key, name`
-	data, err := sqliteJSON(ctx, path, query)
+	whereClause := " WHERE " + strings.Join(partitionPredicates, " AND ")
+	siteClause := selectedCookieClause(selectedSites, true)
+	query := `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + whereClause + siteClause + ` ORDER BY host_key, name`
+	data, err := sqliteJSON(ctx, snapshot, query)
 	if err != nil {
 		return nil, fmt.Errorf("read browser cookies: %w", err)
 	}
@@ -254,19 +276,183 @@ func CountCookiesBySite(cookies []Cookie, sites []Site) []Site {
 }
 
 func sqliteJSON(ctx context.Context, databasePath, query string) ([]byte, error) {
-	command := exec.CommandContext(ctx, "/usr/bin/sqlite3", "-readonly", "-json", databasePath, query)
-	output, err := command.Output()
+	command := exec.CommandContext(ctx, "/usr/bin/sqlite3", "-json", databasePath, query)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	stdout, err := command.StdoutPipe()
 	if err != nil {
-		var exit *exec.ExitError
-		if errors.As(err, &exit) {
-			return nil, fmt.Errorf("sqlite3: %s", strings.TrimSpace(string(exit.Stderr)))
-		}
 		return nil, err
 	}
-	if len(output) > maxSQLiteOutput {
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+	output, readErr := io.ReadAll(io.LimitReader(stdout, maxSQLiteOutput+1))
+	if int64(len(output)) > maxSQLiteOutput {
+		_ = command.Process.Kill()
+		_ = command.Wait()
 		return nil, fmt.Errorf("sqlite output exceeds 64 MiB")
 	}
+	waitErr := command.Wait()
+	if readErr != nil {
+		return nil, readErr
+	}
+	err = waitErr
+	if err != nil {
+		return nil, fmt.Errorf("sqlite3: %s", strings.TrimSpace(stderr.String()))
+	}
 	return output, nil
+}
+
+func sqliteSnapshotJSON(ctx context.Context, databasePath, query string) ([]byte, error) {
+	snapshot, cleanup, err := sqliteSnapshot(ctx, databasePath)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	return sqliteJSON(ctx, snapshot, query)
+}
+
+type fileFingerprint struct {
+	exists   bool
+	size     int64
+	modified time.Time
+}
+
+func sqliteSnapshot(ctx context.Context, databasePath string) (string, func(), error) {
+	if !fileExists(databasePath) {
+		return "", nil, fmt.Errorf("browser database %q was not found", filepath.Base(databasePath))
+	}
+	paths := []string{databasePath, databasePath + "-wal", databasePath + "-journal"}
+	for attempt := 0; attempt < 3; attempt++ {
+		before, err := fingerprintFiles(paths)
+		if err != nil {
+			return "", nil, err
+		}
+		var totalBytes int64
+		for _, fingerprint := range before {
+			totalBytes += fingerprint.size
+		}
+		if totalBytes > maxSQLiteBytes {
+			return "", nil, fmt.Errorf("browser database snapshot exceeds %d bytes", maxSQLiteBytes)
+		}
+		temporaryDirectory, err := os.MkdirTemp("", "kernel-browser-import-sqlite-")
+		if err != nil {
+			return "", nil, err
+		}
+		snapshot := filepath.Join(temporaryDirectory, filepath.Base(databasePath))
+		copyChanged := false
+		for index, source := range paths {
+			if !before[index].exists {
+				continue
+			}
+			if err := copyFileBounded(ctx, source, snapshot+strings.TrimPrefix(source, databasePath), before[index].size); err != nil {
+				os.RemoveAll(temporaryDirectory)
+				if errors.Is(err, os.ErrNotExist) || errors.Is(err, errFileGrew) {
+					copyChanged = true
+					break
+				}
+				return "", nil, fmt.Errorf("copy %s: %w", filepath.Base(source), err)
+			}
+		}
+		after, err := fingerprintFiles(paths)
+		if !copyChanged && err == nil && fingerprintsEqual(before, after) {
+			return snapshot, func() { _ = os.RemoveAll(temporaryDirectory) }, nil
+		}
+		os.RemoveAll(temporaryDirectory)
+	}
+	return "", nil, fmt.Errorf("browser database changed while it was being read; try again")
+}
+
+func fingerprintFiles(paths []string) ([]fileFingerprint, error) {
+	result := make([]fileFingerprint, len(paths))
+	for index, path := range paths {
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		result[index] = fileFingerprint{exists: true, size: info.Size(), modified: info.ModTime()}
+	}
+	return result, nil
+}
+
+func fingerprintsEqual(left, right []fileFingerprint) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func copyFileBounded(ctx context.Context, source, destination string, limit int64) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	buffer := make([]byte, 256<<10)
+	var copied int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		read, readErr := input.Read(buffer)
+		if read > 0 {
+			copied += int64(read)
+			if copied > limit {
+				return errFileGrew
+			}
+			if _, err := output.Write(buffer[:read]); err != nil {
+				return err
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			return output.Close()
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+}
+
+var errFileGrew = errors.New("file grew while being copied")
+
+func selectedCookieClause(sites []string, hasWhere bool) string {
+	if len(sites) == 0 {
+		return ""
+	}
+	predicates := make([]string, 0, len(sites))
+	for _, site := range sites {
+		site = strings.TrimPrefix(strings.ToLower(site), ".")
+		predicates = append(predicates, "(host_key = "+sqliteLiteral(site)+" OR host_key = "+sqliteLiteral("."+site)+" OR host_key LIKE "+sqliteLiteral("%."+site)+")")
+	}
+	prefix := " WHERE "
+	if hasWhere {
+		prefix = " AND "
+	}
+	return prefix + "(" + strings.Join(predicates, " OR ") + ")"
+}
+
+func sqliteLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func chromiumSafeStorageKey(ctx context.Context, browser Browser) ([]byte, error) {
@@ -309,13 +495,17 @@ func decryptChromiumValue(key []byte, domain string, encrypted []byte) ([]byte, 
 	return plaintext, nil
 }
 
-func registrableDomain(host string) string {
-	host = strings.TrimSuffix(strings.ToLower(host), ".")
-	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
-	if err == nil {
-		return domain
+// CanonicalSite validates a website hostname and returns its registrable domain.
+func CanonicalSite(value string) (string, error) {
+	value = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(value)), ".")
+	if value == "" || strings.ContainsAny(value, "/:*@?#[] ") {
+		return "", fmt.Errorf("%q is not a website domain", value)
 	}
-	return host
+	domain, err := publicsuffix.EffectiveTLDPlusOne(value)
+	if err != nil {
+		return "", fmt.Errorf("%q is not a registrable website domain", value)
+	}
+	return domain, nil
 }
 
 func matchesAnySite(cookieDomain string, sites []string) bool {

--- a/internal/browserimport/chromium.go
+++ b/internal/browserimport/chromium.go
@@ -1,0 +1,369 @@
+package browserimport
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/net/publicsuffix"
+)
+
+const (
+	maxDocumentBytes = 16 << 20
+	maxSQLiteOutput  = 64 << 20
+)
+
+var profileIDCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func DiscoverMacOSProfiles(home string) ([]Profile, error) {
+	browsers := []Browser{
+		{ID: "chrome", Name: "Google Chrome", Root: filepath.Join(home, "Library/Application Support/Google/Chrome"), Keychain: KeychainIdentity{Service: "Chrome Safe Storage", Account: "Chrome"}},
+		{ID: "helium", Name: "Helium", Root: filepath.Join(home, "Library/Application Support/net.imput.helium"), Keychain: KeychainIdentity{Service: "Helium Storage Key", Account: "Helium"}},
+	}
+	profiles := make([]Profile, 0)
+	for _, browser := range browsers {
+		found, err := discoverProfiles(browser)
+		if err != nil {
+			return nil, fmt.Errorf("discover %s profiles: %w", browser.Name, err)
+		}
+		profiles = append(profiles, found...)
+	}
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].DisplayName() < profiles[j].DisplayName() })
+	return profiles, nil
+}
+
+func discoverProfiles(browser Browser) ([]Profile, error) {
+	if _, err := os.Stat(browser.Root); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	names := make(map[string]string)
+	data, err := readFileBounded(filepath.Join(browser.Root, "Local State"), maxDocumentBytes)
+	if err == nil {
+		var state struct {
+			Profile struct {
+				InfoCache map[string]struct {
+					Name string `json:"name"`
+				} `json:"info_cache"`
+			} `json:"profile"`
+		}
+		if json.Unmarshal(data, &state) == nil {
+			for directory, info := range state.Profile.InfoCache {
+				names[directory] = info.Name
+			}
+		}
+	}
+	if len(names) == 0 {
+		entries, err := os.ReadDir(browser.Root)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() && (entry.Name() == "Default" || strings.HasPrefix(entry.Name(), "Profile ")) {
+				names[entry.Name()] = entry.Name()
+			}
+		}
+	}
+
+	directories := make([]string, 0, len(names))
+	for directory := range names {
+		directories = append(directories, directory)
+	}
+	sort.Strings(directories)
+	profiles := make([]Profile, 0, len(directories))
+	for _, directory := range directories {
+		path := filepath.Join(browser.Root, directory)
+		if _, err := os.Stat(filepath.Join(path, "History")); err != nil {
+			continue
+		}
+		profiles = append(profiles, Profile{ID: profileID(browser.ID, directory), Name: names[directory], Browser: browser, Path: path})
+	}
+	return profiles, nil
+}
+
+func profileID(browserID, directory string) string {
+	value := strings.Trim(profileIDCharacters.ReplaceAllString(strings.ToLower(browserID+"-"+directory), "-"), "-")
+	digest := sha256.Sum256([]byte(browserID + "\x00" + directory))
+	return value + "-" + hex.EncodeToString(digest[:4])
+}
+
+func RecentSites(ctx context.Context, profile Profile, since time.Time, limit int) ([]Site, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("site limit must be positive")
+	}
+	const chromeEpochMicros = int64(11_644_473_600_000_000)
+	cutoff := since.UnixMicro() + chromeEpochMicros
+	query := fmt.Sprintf(`SELECT u.url, COUNT(*) AS visits, MAX(v.visit_time) AS last_visit FROM visits v JOIN urls u ON u.id = v.url WHERE v.visit_time >= %d AND (u.url LIKE 'http://%%' OR u.url LIKE 'https://%%') GROUP BY u.url ORDER BY visits DESC, last_visit DESC LIMIT 10000`, cutoff)
+	data, err := sqliteJSON(ctx, filepath.Join(profile.Path, "History"), query)
+	if err != nil {
+		return nil, fmt.Errorf("read recent browser history: %w", err)
+	}
+	var rows []struct {
+		URL       string `json:"url"`
+		Visits    int    `json:"visits"`
+		LastVisit int64  `json:"last_visit"`
+	}
+	if len(bytes.TrimSpace(data)) != 0 {
+		if err := json.Unmarshal(data, &rows); err != nil {
+			return nil, fmt.Errorf("decode recent browser history: %w", err)
+		}
+	}
+
+	byDomain := make(map[string]Site)
+	for _, row := range rows {
+		parsed, err := url.Parse(row.URL)
+		if err != nil || parsed.Hostname() == "" {
+			continue
+		}
+		domain := registrableDomain(parsed.Hostname())
+		site := byDomain[domain]
+		site.Domain = domain
+		site.Visits += row.Visits
+		visited := chromiumTime(row.LastVisit)
+		if visited.After(site.LastVisited) {
+			site.LastVisited = visited
+		}
+		byDomain[domain] = site
+	}
+	sites := make([]Site, 0, len(byDomain))
+	for _, site := range byDomain {
+		sites = append(sites, site)
+	}
+	sort.Slice(sites, func(i, j int) bool {
+		if sites[i].Visits == sites[j].Visits {
+			return sites[i].LastVisited.After(sites[j].LastVisited)
+		}
+		return sites[i].Visits > sites[j].Visits
+	})
+	if len(sites) > limit {
+		sites = sites[:limit]
+	}
+	return sites, nil
+}
+
+func ExportCookies(ctx context.Context, profile Profile, selectedSites []string) ([]Cookie, error) {
+	path := filepath.Join(profile.Path, "Network/Cookies")
+	if _, err := os.Stat(path); err != nil {
+		path = filepath.Join(profile.Path, "Cookies")
+	}
+	columnsData, err := sqliteJSON(ctx, path, `SELECT name FROM pragma_table_info('cookies')`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect cookie database: %w", err)
+	}
+	var columns []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(columnsData, &columns); err != nil {
+		return nil, fmt.Errorf("decode cookie schema: %w", err)
+	}
+	partitionClause := ""
+	for _, column := range columns {
+		switch column.Name {
+		case "top_frame_site_key":
+			partitionClause = " WHERE top_frame_site_key = ''"
+		case "is_partitioned":
+			if partitionClause == "" {
+				partitionClause = " WHERE is_partitioned = 0"
+			}
+		}
+	}
+	query := `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + partitionClause + ` ORDER BY host_key, name`
+	data, err := sqliteJSON(ctx, path, query)
+	if err != nil {
+		return nil, fmt.Errorf("read browser cookies: %w", err)
+	}
+	var rows []struct {
+		Domain       string `json:"host_key"`
+		Path         string `json:"path"`
+		Name         string `json:"name"`
+		Value        string `json:"value"`
+		EncryptedHex string `json:"encrypted_value"`
+		Expires      int64  `json:"expires_utc"`
+		HTTPOnly     int    `json:"is_httponly"`
+		Secure       int    `json:"is_secure"`
+		SameSite     int    `json:"samesite"`
+	}
+	if len(bytes.TrimSpace(data)) != 0 {
+		if err := json.Unmarshal(data, &rows); err != nil {
+			return nil, fmt.Errorf("decode browser cookies: %w", err)
+		}
+	}
+	var key []byte
+	cookies := make([]Cookie, 0)
+	for _, row := range rows {
+		if !matchesAnySite(row.Domain, selectedSites) {
+			continue
+		}
+		value := row.Value
+		if value == "" && row.EncryptedHex != "" {
+			if key == nil {
+				key, err = chromiumSafeStorageKey(ctx, profile.Browser)
+				if err != nil {
+					return nil, err
+				}
+			}
+			encrypted, err := hex.DecodeString(row.EncryptedHex)
+			if err != nil {
+				return nil, fmt.Errorf("decode cookie %s: %w", row.Name, err)
+			}
+			decrypted, err := decryptChromiumValue(key, row.Domain, encrypted)
+			if err != nil {
+				return nil, fmt.Errorf("decrypt cookie %s: %w", row.Name, err)
+			}
+			value = string(decrypted)
+		}
+		cookie := Cookie{Domain: row.Domain, Path: row.Path, Name: row.Name, Value: value, HTTPOnly: row.HTTPOnly != 0, Secure: row.Secure != 0, SameSite: chromiumSameSite(row.SameSite, row.Secure != 0)}
+		if row.Expires > 0 {
+			expires := chromiumTime(row.Expires)
+			cookie.ExpiresAt = &expires
+		}
+		cookies = append(cookies, cookie)
+	}
+	return cookies, nil
+}
+
+func CountCookiesBySite(cookies []Cookie, sites []Site) []Site {
+	result := append([]Site(nil), sites...)
+	for i := range result {
+		for _, cookie := range cookies {
+			if domainMatchesSite(cookie.Domain, result[i].Domain) {
+				result[i].CookieCount++
+			}
+		}
+	}
+	return result
+}
+
+func sqliteJSON(ctx context.Context, databasePath, query string) ([]byte, error) {
+	command := exec.CommandContext(ctx, "/usr/bin/sqlite3", "-readonly", "-json", databasePath, query)
+	output, err := command.Output()
+	if err != nil {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			return nil, fmt.Errorf("sqlite3: %s", strings.TrimSpace(string(exit.Stderr)))
+		}
+		return nil, err
+	}
+	if len(output) > maxSQLiteOutput {
+		return nil, fmt.Errorf("sqlite output exceeds 64 MiB")
+	}
+	return output, nil
+}
+
+func chromiumSafeStorageKey(ctx context.Context, browser Browser) ([]byte, error) {
+	command := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password", "-w", "-s", browser.Keychain.Service, "-a", browser.Keychain.Account)
+	password, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("allow %s cookie access in macOS Keychain", browser.Name)
+	}
+	return pbkdf2.Key([]byte(strings.TrimSpace(string(password))), []byte("saltysalt"), 1003, 16, sha1.New), nil
+}
+
+func decryptChromiumValue(key []byte, domain string, encrypted []byte) ([]byte, error) {
+	if len(encrypted) < 3 || (string(encrypted[:3]) != "v10" && string(encrypted[:3]) != "v11") {
+		return nil, fmt.Errorf("unsupported encrypted value format")
+	}
+	ciphertext := encrypted[3:]
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("encrypted value has invalid length")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	plaintext := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, bytes.Repeat([]byte{' '}, aes.BlockSize)).CryptBlocks(plaintext, ciphertext)
+	padding := int(plaintext[len(plaintext)-1])
+	if padding == 0 || padding > aes.BlockSize || padding > len(plaintext) {
+		return nil, fmt.Errorf("encrypted value has invalid padding")
+	}
+	for _, value := range plaintext[len(plaintext)-padding:] {
+		if int(value) != padding {
+			return nil, fmt.Errorf("encrypted value has invalid padding")
+		}
+	}
+	plaintext = plaintext[:len(plaintext)-padding]
+	hostDigest := sha256.Sum256([]byte(domain))
+	if len(plaintext) >= len(hostDigest) && bytes.Equal(plaintext[:len(hostDigest)], hostDigest[:]) {
+		plaintext = plaintext[len(hostDigest):]
+	}
+	return plaintext, nil
+}
+
+func registrableDomain(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	domain, err := publicsuffix.EffectiveTLDPlusOne(host)
+	if err == nil {
+		return domain
+	}
+	return host
+}
+
+func matchesAnySite(cookieDomain string, sites []string) bool {
+	for _, site := range sites {
+		if domainMatchesSite(cookieDomain, site) {
+			return true
+		}
+	}
+	return false
+}
+
+func domainMatchesSite(cookieDomain, site string) bool {
+	cookieDomain = strings.TrimPrefix(strings.ToLower(cookieDomain), ".")
+	site = strings.ToLower(site)
+	return cookieDomain == site || strings.HasSuffix(cookieDomain, "."+site) || strings.HasSuffix(site, "."+cookieDomain)
+}
+
+func chromiumTime(microseconds int64) time.Time {
+	const chromiumToUnixMicroseconds = int64(11_644_473_600_000_000)
+	return time.UnixMicro(microseconds - chromiumToUnixMicroseconds).UTC()
+}
+
+func chromiumSameSite(value int, secure bool) string {
+	switch value {
+	case 1:
+		return "lax"
+	case 2:
+		return "strict"
+	case 0:
+		if secure {
+			return "none"
+		}
+	}
+	return ""
+}
+
+func readFileBounded(path string, limit int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("file exceeds %d bytes", limit)
+	}
+	return data, nil
+}

--- a/internal/browserimport/chromium_test.go
+++ b/internal/browserimport/chromium_test.go
@@ -1,0 +1,74 @@
+package browserimport
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverMacOSProfilesFindsChromeAndHelium(t *testing.T) {
+	home := t.TempDir()
+	writeBrowserFixture(t, home, "Google/Chrome", "Default", "Personal")
+	writeBrowserFixture(t, home, "net.imput.helium", "Profile 1", "Work")
+
+	profiles, err := DiscoverMacOSProfiles(home)
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "Google Chrome / Personal", profiles[0].DisplayName())
+	assert.Equal(t, "Helium / Work", profiles[1].DisplayName())
+	assert.NotEqual(t, profiles[0].ID, profiles[1].ID)
+}
+
+func TestRegistrableDomainGroupsSubdomains(t *testing.T) {
+	assert.Equal(t, "example.co.uk", registrableDomain("login.example.co.uk"))
+	assert.Equal(t, "localhost", registrableDomain("localhost"))
+}
+
+func TestDomainMatchesSelectedSite(t *testing.T) {
+	assert.True(t, domainMatchesSite(".accounts.google.com", "google.com"))
+	assert.True(t, domainMatchesSite("google.com", "accounts.google.com"))
+	assert.False(t, domainMatchesSite("notgoogle.com", "google.com"))
+}
+
+func TestDecryptChromiumValueSupportsHostDigest(t *testing.T) {
+	key := []byte("0123456789abcdef")
+	domain := ".example.com"
+	digest := sha256.Sum256([]byte(domain))
+	plaintext := append(digest[:], []byte("secret")...)
+	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
+	plaintext = append(plaintext, bytesRepeat(byte(padding), padding)...)
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	ciphertext := make([]byte, len(plaintext))
+	cipher.NewCBCEncrypter(block, bytesRepeat(' ', aes.BlockSize)).CryptBlocks(ciphertext, plaintext)
+
+	decrypted, err := decryptChromiumValue(key, domain, append([]byte("v10"), ciphertext...))
+	require.NoError(t, err)
+	assert.Equal(t, "secret", string(decrypted))
+}
+
+func writeBrowserFixture(t *testing.T, home, rootSuffix, directory, name string) {
+	t.Helper()
+	root := filepath.Join(home, "Library/Application Support", rootSuffix)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, directory), 0o755))
+	state := map[string]any{"profile": map[string]any{"info_cache": map[string]any{directory: map[string]string{"name": name}}}}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Local State"), data, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, directory, "History"), nil, 0o600))
+}
+
+func bytesRepeat(value byte, count int) []byte {
+	result := make([]byte, count)
+	for i := range result {
+		result[i] = value
+	}
+	return result
+}

--- a/internal/browserimport/chromium_test.go
+++ b/internal/browserimport/chromium_test.go
@@ -1,13 +1,17 @@
 package browserimport
 
 import (
+	"bufio"
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,15 +30,20 @@ func TestDiscoverMacOSProfilesFindsChromeAndHelium(t *testing.T) {
 	assert.NotEqual(t, profiles[0].ID, profiles[1].ID)
 }
 
-func TestRegistrableDomainGroupsSubdomains(t *testing.T) {
-	assert.Equal(t, "example.co.uk", registrableDomain("login.example.co.uk"))
-	assert.Equal(t, "localhost", registrableDomain("localhost"))
-}
-
 func TestDomainMatchesSelectedSite(t *testing.T) {
 	assert.True(t, domainMatchesSite(".accounts.google.com", "google.com"))
 	assert.True(t, domainMatchesSite("google.com", "accounts.google.com"))
 	assert.False(t, domainMatchesSite("notgoogle.com", "google.com"))
+}
+
+func TestCanonicalSiteUsesRegistrableDomain(t *testing.T) {
+	domain, err := CanonicalSite("accounts.Google.com")
+	require.NoError(t, err)
+	assert.Equal(t, "google.com", domain)
+	_, err = CanonicalSite("com")
+	assert.Error(t, err)
+	_, err = CanonicalSite("https://google.com")
+	assert.Error(t, err)
 }
 
 func TestDecryptChromiumValueSupportsHostDigest(t *testing.T) {
@@ -54,6 +63,156 @@ func TestDecryptChromiumValueSupportsHostDigest(t *testing.T) {
 	assert.Equal(t, "secret", string(decrypted))
 }
 
+func TestRecentSitesRanksDomainsFromWALDatabase(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "History")
+	runSQLite(t, database, `
+PRAGMA journal_mode=WAL;
+CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT);
+CREATE TABLE visits (id INTEGER PRIMARY KEY, url INTEGER, visit_time INTEGER);
+INSERT INTO urls VALUES (1, 'https://github.com/a'), (2, 'https://www.github.com/b'), (3, 'https://example.com');
+INSERT INTO visits VALUES (1, 1, 13400000000000000), (2, 2, 13400000001000000), (3, 3, 13400000002000000);
+`)
+
+	sites, err := RecentSites(context.Background(), profile, time.Unix(0, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, sites, 2)
+	assert.Equal(t, "github.com", sites[0].Domain)
+	assert.Equal(t, 2, sites[0].Visits)
+	assert.Equal(t, "example.com", sites[1].Domain)
+}
+
+func TestRecentSitesOmitsNonPortableLocalHosts(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "History")
+	runSQLite(t, database, `
+CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT);
+CREATE TABLE visits (id INTEGER PRIMARY KEY, url INTEGER, visit_time INTEGER);
+INSERT INTO urls VALUES (1, 'http://localhost:3000'), (2, 'https://github.com/kernel');
+INSERT INTO visits VALUES (1, 1, 13400000000000000), (2, 2, 13400000001000000);
+`)
+
+	sites, err := RecentSites(context.Background(), profile, time.Unix(0, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	assert.Equal(t, "github.com", sites[0].Domain)
+}
+
+func TestRecentSitesSnapshotsLockedDatabase(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "History")
+	runSQLite(t, database, `
+PRAGMA journal_mode=WAL;
+CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT);
+CREATE TABLE visits (id INTEGER PRIMARY KEY, url INTEGER, visit_time INTEGER);
+INSERT INTO urls VALUES (1, 'https://github.com/kernel');
+INSERT INTO visits VALUES (1, 1, 13400000000000000);
+`)
+
+	locker := exec.Command("/usr/bin/sqlite3", database)
+	stdin, err := locker.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := locker.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, locker.Start())
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = locker.Process.Kill()
+		_ = locker.Wait()
+	})
+	_, err = stdin.Write([]byte("PRAGMA locking_mode=EXCLUSIVE; BEGIN EXCLUSIVE;\n.print READY\n"))
+	require.NoError(t, err)
+	require.True(t, bufio.NewScanner(stdout).Scan())
+
+	direct := exec.Command("/usr/bin/sqlite3", "-readonly", database, "SELECT COUNT(*) FROM visits")
+	require.Error(t, direct.Run(), "fixture must prove the source database is locked")
+	sites, err := RecentSites(context.Background(), profile, time.Unix(0, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	assert.Equal(t, "github.com", sites[0].Domain)
+}
+
+func TestRecentSitesSnapshotsRollbackJournal(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "History")
+	runSQLite(t, database, `
+CREATE TABLE urls (id INTEGER PRIMARY KEY, url TEXT);
+CREATE TABLE visits (id INTEGER PRIMARY KEY, url INTEGER, visit_time INTEGER);
+INSERT INTO urls VALUES (1, 'https://github.com/kernel');
+INSERT INTO visits VALUES (1, 1, 13400000000000000);
+`)
+
+	locker := exec.Command("/usr/bin/sqlite3", database)
+	stdin, err := locker.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := locker.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, locker.Start())
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = locker.Process.Kill()
+		_ = locker.Wait()
+	})
+	_, err = stdin.Write([]byte("PRAGMA journal_mode=DELETE; PRAGMA locking_mode=EXCLUSIVE; BEGIN EXCLUSIVE; UPDATE urls SET url = 'https://uncommitted.example';\n.print READY\n"))
+	require.NoError(t, err)
+	require.True(t, bufio.NewScanner(stdout).Scan())
+	require.FileExists(t, database+"-journal")
+
+	sites, err := RecentSites(context.Background(), profile, time.Unix(0, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, sites, 1)
+	assert.Equal(t, "github.com", sites[0].Domain, "the copied hot journal must roll back the uncommitted page")
+}
+
+func TestExportCookiesFiltersSitesAndPartitionedRows(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "Network", "Cookies")
+	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
+	runSQLite(t, database, `
+CREATE TABLE cookies (
+  host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+  expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER,
+  top_frame_site_key TEXT
+);
+INSERT INTO cookies VALUES
+  ('.github.com', '/', 'session', 'selected', X'', 0, 1, 1, 1, ''),
+  ('.github.com', '/', 'partitioned', 'exclude', X'', 13400000000000000, 0, 1, 0, 'https://top.example'),
+  ('.github.com', '/', 'expired', 'exclude', X'', 13400000000000000, 0, 1, 0, ''),
+  ('.unrelated.com', '/', 'other', 'exclude', X'', 13400000000000000, 0, 1, 0, '');
+`)
+
+	cookies, err := ExportCookies(context.Background(), profile, []string{"github.com"})
+	require.NoError(t, err)
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "session", cookies[0].Name)
+	assert.Equal(t, "selected", cookies[0].Value)
+	assert.Equal(t, "lax", cookies[0].SameSite)
+}
+
+func TestExportCookiesIncludesParentDomainForSelectedSubdomain(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "Network", "Cookies")
+	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
+	runSQLite(t, database, `
+CREATE TABLE cookies (
+  host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+  expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER
+);
+INSERT INTO cookies VALUES ('.google.com', '/', 'parent', 'selected', X'', 0, 1, 1, 1);
+`)
+
+	cookies, err := ExportCookies(context.Background(), profile, []string{"accounts.google.com"})
+	require.NoError(t, err)
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "parent", cookies[0].Name)
+}
+
+func TestSelectedCookieClauseEscapesInput(t *testing.T) {
+	clause := selectedCookieClause([]string{"example.com' OR 1=1 --"}, false)
+	assert.Contains(t, clause, "example.com'' or 1=1 --")
+	assert.NotContains(t, clause, "example.com' OR 1=1 --'")
+}
+
 func writeBrowserFixture(t *testing.T, home, rootSuffix, directory, name string) {
 	t.Helper()
 	root := filepath.Join(home, "Library/Application Support", rootSuffix)
@@ -63,6 +222,20 @@ func writeBrowserFixture(t *testing.T, home, rootSuffix, directory, name string)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(root, "Local State"), data, 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(root, directory, "History"), nil, 0o600))
+}
+
+func sqliteProfileFixture(t *testing.T) Profile {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "Default")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	return Profile{ID: "chrome-default", Name: "Personal", Browser: Browser{ID: "chrome", Name: "Google Chrome"}, Path: path}
+}
+
+func runSQLite(t *testing.T, database, statement string) {
+	t.Helper()
+	command := exec.Command("/usr/bin/sqlite3", database, statement)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
 }
 
 func bytesRepeat(value byte, count int) []byte {

--- a/internal/browserimport/client.go
+++ b/internal/browserimport/client.go
@@ -1,0 +1,157 @@
+package browserimport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL   string
+	token     string
+	projectID string
+	http      *http.Client
+}
+
+func NewClient(baseURL, token, projectID string) (*Client, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid Kernel API URL")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1")) {
+		return nil, fmt.Errorf("Kernel API URL must use HTTPS or local development")
+	}
+	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), token: token, projectID: projectID, http: &http.Client{Timeout: 15 * time.Minute}}, nil
+}
+
+func (c *Client) Create(ctx context.Context) (CreateResponse, error) {
+	var result CreateResponse
+	err := c.doJSON(ctx, http.MethodPost, "/browser-imports", c.token, nil, &result)
+	return result, err
+}
+
+func (c *Client) SubmitInventory(ctx context.Context, id, helperToken string, inventory Inventory) (Status, error) {
+	var result Status
+	err := c.doJSON(ctx, http.MethodPost, "/browser-imports/"+url.PathEscape(id)+"/inventory", helperToken, inventory, &result)
+	return result, err
+}
+
+func (c *Client) SubmitSelection(ctx context.Context, id string, selection Selection) (Status, error) {
+	var result Status
+	err := c.doJSON(ctx, http.MethodPost, "/browser-imports/"+url.PathEscape(id)+"/selection", c.token, selection, &result)
+	return result, err
+}
+
+func (c *Client) Upload(ctx context.Context, id, helperToken string, bundle []byte) (Status, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/browser-imports/"+url.PathEscape(id)+"/bundle", bytes.NewReader(bundle))
+	if err != nil {
+		return Status{}, err
+	}
+	c.setHeaders(request, helperToken)
+	request.Header.Set("Content-Type", "application/octet-stream")
+	response, err := c.http.Do(request)
+	if err != nil {
+		return Status{}, err
+	}
+	defer response.Body.Close()
+	var result Status
+	if err := decodeResponse(response, &result); err != nil {
+		return Status{}, err
+	}
+	return result, nil
+}
+
+func (c *Client) Status(ctx context.Context, id string) (Status, error) {
+	var result Status
+	err := c.doJSON(ctx, http.MethodGet, "/browser-imports/"+url.PathEscape(id), c.token, nil, &result)
+	return result, err
+}
+
+func (c *Client) Wait(ctx context.Context, id string, interval time.Duration) (Status, error) {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		status, err := c.Status(ctx, id)
+		if err != nil {
+			return Status{}, err
+		}
+		switch status.Phase {
+		case "completed":
+			return status, nil
+		case "failed":
+			if status.Applied != nil && status.Applied.Failure != nil {
+				return status, fmt.Errorf("browser import failed during %s: %s", status.Applied.Failure.Stage, status.Applied.Failure.Message)
+			}
+			return status, fmt.Errorf("browser import failed")
+		}
+		select {
+		case <-ctx.Done():
+			return Status{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path, token string, body any, output any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	c.setHeaders(request, token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	return decodeResponse(response, output)
+}
+
+func (c *Client) setHeaders(request *http.Request, token string) {
+	request.Header.Set("Authorization", "Bearer "+token)
+	if c.projectID != "" {
+		request.Header.Set("X-Kernel-Project-Id", c.projectID)
+	}
+}
+
+func decodeResponse(response *http.Response, output any) error {
+	data, err := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var apiError struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(data, &apiError) == nil && apiError.Message != "" {
+			return fmt.Errorf("Kernel API returned %d: %s", response.StatusCode, apiError.Message)
+		}
+		return fmt.Errorf("Kernel API returned %d", response.StatusCode)
+	}
+	if output == nil || len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, output); err != nil {
+		return fmt.Errorf("decode Kernel API response: %w", err)
+	}
+	return nil
+}

--- a/internal/browserimport/client.go
+++ b/internal/browserimport/client.go
@@ -20,6 +20,18 @@ type Client struct {
 	http      *http.Client
 }
 
+type responseError struct {
+	status  int
+	message string
+}
+
+func (e *responseError) Error() string {
+	if e.message != "" {
+		return fmt.Sprintf("Kernel API returned %d: %s", e.status, e.message)
+	}
+	return fmt.Sprintf("Kernel API returned %d", e.status)
+}
+
 func NewClient(baseURL, token, projectID string) (*Client, error) {
 	parsed, err := url.Parse(baseURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
@@ -34,7 +46,10 @@ func NewClient(baseURL, token, projectID string) (*Client, error) {
 		return nil, fmt.Errorf("Kernel API URL must use HTTPS or local development")
 	}
 	parsed.Path = ""
-	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), token: token, projectID: projectID, http: &http.Client{Timeout: 15 * time.Minute}}, nil
+	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), token: token, projectID: projectID, http: &http.Client{
+		Timeout:       15 * time.Minute,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}}, nil
 }
 
 func (c *Client) Create(ctx context.Context) (CreateResponse, error) {
@@ -105,19 +120,25 @@ func (c *Client) Wait(ctx context.Context, id string, interval time.Duration) (S
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	consecutiveErrors := 0
 	for {
 		status, err := c.Status(ctx, id)
 		if err != nil {
-			return Status{}, err
-		}
-		switch status.Phase {
-		case "completed":
-			return status, nil
-		case "failed":
-			if status.Applied != nil && status.Applied.Failure != nil {
-				return status, fmt.Errorf("browser import failed during %s: %s", status.Applied.Failure.Stage, status.Applied.Failure.Message)
+			consecutiveErrors++
+			if !transientStatusError(err) || consecutiveErrors >= 3 {
+				return Status{}, err
 			}
-			return status, fmt.Errorf("browser import failed")
+		} else {
+			consecutiveErrors = 0
+			switch status.Phase {
+			case "completed":
+				return status, nil
+			case "failed":
+				if status.Applied != nil && status.Applied.Failure != nil {
+					return status, fmt.Errorf("browser import failed during %s: %s", status.Applied.Failure.Stage, status.Applied.Failure.Message)
+				}
+				return status, fmt.Errorf("browser import failed")
+			}
 		}
 		select {
 		case <-ctx.Done():
@@ -125,6 +146,14 @@ func (c *Client) Wait(ctx context.Context, id string, interval time.Duration) (S
 		case <-ticker.C:
 		}
 	}
+}
+
+func transientStatusError(err error) bool {
+	var responseErr *responseError
+	if !errors.As(err, &responseErr) {
+		return true
+	}
+	return responseErr.status == http.StatusRequestTimeout || responseErr.status == http.StatusTooManyRequests || responseErr.status >= 500
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path, token string, body any, output any) error {
@@ -169,9 +198,9 @@ func decodeResponse(response *http.Response, output any) error {
 			Message string `json:"message"`
 		}
 		if json.Unmarshal(data, &apiError) == nil && apiError.Message != "" {
-			return fmt.Errorf("Kernel API returned %d: %s", response.StatusCode, apiError.Message)
+			return &responseError{status: response.StatusCode, message: apiError.Message}
 		}
-		return fmt.Errorf("Kernel API returned %d", response.StatusCode)
+		return &responseError{status: response.StatusCode}
 	}
 	if output == nil || len(bytes.TrimSpace(data)) == 0 {
 		return nil

--- a/internal/browserimport/client.go
+++ b/internal/browserimport/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,9 +25,15 @@ func NewClient(baseURL, token, projectID string) (*Client, error) {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return nil, fmt.Errorf("invalid Kernel API URL")
 	}
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1")) {
+	if parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("Kernel API URL must not contain credentials, a path, query, or fragment")
+	}
+	local := parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1")
+	official := parsed.Scheme == "https" && (parsed.Hostname() == "api.onkernel.com" || strings.HasSuffix(parsed.Hostname(), ".onkernel.com"))
+	if !local && !official {
 		return nil, fmt.Errorf("Kernel API URL must use HTTPS or local development")
 	}
+	parsed.Path = ""
 	return &Client{baseURL: strings.TrimRight(parsed.String(), "/"), token: token, projectID: projectID, http: &http.Client{Timeout: 15 * time.Minute}}, nil
 }
 
@@ -39,12 +46,18 @@ func (c *Client) Create(ctx context.Context) (CreateResponse, error) {
 func (c *Client) SubmitInventory(ctx context.Context, id, helperToken string, inventory Inventory) (Status, error) {
 	var result Status
 	err := c.doJSON(ctx, http.MethodPost, "/browser-imports/"+url.PathEscape(id)+"/inventory", helperToken, inventory, &result)
+	if err != nil {
+		return c.reconcile(ctx, id, err, "awaiting_selection", "awaiting_bundle", "staged", "applying", "completed")
+	}
 	return result, err
 }
 
 func (c *Client) SubmitSelection(ctx context.Context, id string, selection Selection) (Status, error) {
 	var result Status
 	err := c.doJSON(ctx, http.MethodPost, "/browser-imports/"+url.PathEscape(id)+"/selection", c.token, selection, &result)
+	if err != nil {
+		return c.reconcile(ctx, id, err, "awaiting_bundle", "staged", "applying", "completed")
+	}
 	return result, err
 }
 
@@ -57,14 +70,27 @@ func (c *Client) Upload(ctx context.Context, id, helperToken string, bundle []by
 	request.Header.Set("Content-Type", "application/octet-stream")
 	response, err := c.http.Do(request)
 	if err != nil {
-		return Status{}, err
+		return c.reconcile(ctx, id, err, "staged", "applying", "completed", "failed")
 	}
 	defer response.Body.Close()
 	var result Status
 	if err := decodeResponse(response, &result); err != nil {
-		return Status{}, err
+		return c.reconcile(ctx, id, err, "staged", "applying", "completed", "failed")
 	}
 	return result, nil
+}
+
+func (c *Client) reconcile(ctx context.Context, id string, requestErr error, advancedPhases ...string) (Status, error) {
+	status, statusErr := c.Status(ctx, id)
+	if statusErr != nil {
+		return Status{}, errors.Join(requestErr, fmt.Errorf("check browser import %s after request failure: %w", id, statusErr))
+	}
+	for _, phase := range advancedPhases {
+		if status.Phase == phase {
+			return status, nil
+		}
+	}
+	return status, requestErr
 }
 
 func (c *Client) Status(ctx context.Context, id string) (Status, error) {

--- a/internal/browserimport/client_test.go
+++ b/internal/browserimport/client_test.go
@@ -67,3 +67,43 @@ func TestClientRejectsUntrustedPlaintextAPI(t *testing.T) {
 	_, err := NewClient("http://api.example.com", "token", "")
 	assert.EqualError(t, err, "Kernel API URL must use HTTPS or local development")
 }
+
+func TestClientRejectsUntrustedHTTPSAPI(t *testing.T) {
+	_, err := NewClient("https://evil.example", "token", "")
+	assert.EqualError(t, err, "Kernel API URL must use HTTPS or local development")
+}
+
+func TestClientRejectsAPIURLWithPath(t *testing.T) {
+	_, err := NewClient("https://api.onkernel.com/steal", "token", "")
+	assert.EqualError(t, err, "Kernel API URL must not contain credentials, a path, query, or fragment")
+}
+
+func TestClientAcceptsOfficialAPIURLWithTrailingSlash(t *testing.T) {
+	_, err := NewClient("https://api.onkernel.com/", "token", "")
+	require.NoError(t, err)
+}
+
+func TestSubmitInventoryReconcilesAcceptedResponseLoss(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method + " " + request.URL.Path {
+		case "POST /browser-imports/imp_1/inventory":
+			requests.Add(1)
+			hijacker := response.(http.Hijacker)
+			connection, _, err := hijacker.Hijack()
+			require.NoError(t, err)
+			connection.Close()
+		case "GET /browser-imports/imp_1":
+			fmt.Fprint(response, `{"id":"imp_1","phase":"awaiting_selection"}`)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "user-token", "")
+	require.NoError(t, err)
+	status, err := client.SubmitInventory(context.Background(), "imp_1", "helper-token", Inventory{Sources: []Source{{ID: "chrome"}}})
+	require.NoError(t, err)
+	assert.Equal(t, "awaiting_selection", status.Phase)
+	assert.EqualValues(t, 1, requests.Load())
+}

--- a/internal/browserimport/client_test.go
+++ b/internal/browserimport/client_test.go
@@ -1,0 +1,69 @@
+package browserimport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRunsBrowserImportLifecycleWithScopedTokens(t *testing.T) {
+	var statusCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, "proj_test", request.Header.Get("X-Kernel-Project-Id"))
+		switch request.URL.Path {
+		case "/browser-imports":
+			assert.Equal(t, "Bearer user-token", request.Header.Get("Authorization"))
+			response.WriteHeader(http.StatusCreated)
+			fmt.Fprint(response, `{"id":"imp_1","helper_token":"helper-token","helper_token_expires_at":"2030-01-01T00:00:00Z"}`)
+		case "/browser-imports/imp_1/inventory":
+			assert.Equal(t, "Bearer helper-token", request.Header.Get("Authorization"))
+			response.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(response, `{"id":"imp_1","phase":"awaiting_selection"}`)
+		case "/browser-imports/imp_1/selection":
+			assert.Equal(t, "Bearer user-token", request.Header.Get("Authorization"))
+			response.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(response, `{"id":"imp_1","phase":"awaiting_bundle"}`)
+		case "/browser-imports/imp_1/bundle":
+			assert.Equal(t, "Bearer helper-token", request.Header.Get("Authorization"))
+			assert.Equal(t, "application/octet-stream", request.Header.Get("Content-Type"))
+			response.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(response, `{"id":"imp_1","phase":"staged"}`)
+		case "/browser-imports/imp_1":
+			assert.Equal(t, "Bearer user-token", request.Header.Get("Authorization"))
+			phase := "applying"
+			if statusCalls.Add(1) > 1 {
+				phase = "completed"
+			}
+			fmt.Fprintf(response, `{"id":"imp_1","phase":%q}`, phase)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "user-token", "proj_test")
+	require.NoError(t, err)
+	created, err := client.Create(context.Background())
+	require.NoError(t, err)
+	_, err = client.SubmitInventory(context.Background(), created.ID, created.HelperToken, Inventory{Sources: []Source{{ID: "chrome", Kind: "browser", Name: "Chrome", DataTypes: []string{"cookies"}}}})
+	require.NoError(t, err)
+	_, err = client.SubmitSelection(context.Background(), created.ID, Selection{Profiles: []ProfileSelection{}, CredentialSources: []string{}})
+	require.NoError(t, err)
+	_, err = client.Upload(context.Background(), created.ID, created.HelperToken, []byte("bundle"))
+	require.NoError(t, err)
+	status, err := client.Wait(context.Background(), created.ID, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", status.Phase)
+}
+
+func TestClientRejectsUntrustedPlaintextAPI(t *testing.T) {
+	_, err := NewClient("http://api.example.com", "token", "")
+	assert.EqualError(t, err, "Kernel API URL must use HTTPS or local development")
+}

--- a/internal/browserimport/client_test.go
+++ b/internal/browserimport/client_test.go
@@ -107,3 +107,53 @@ func TestSubmitInventoryReconcilesAcceptedResponseLoss(t *testing.T) {
 	assert.Equal(t, "awaiting_selection", status.Phase)
 	assert.EqualValues(t, 1, requests.Load())
 }
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	redirected := atomic.Bool{}
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirected.Store(true)
+	}))
+	defer destination.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Location", destination.URL)
+		response.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "secret-token", "")
+	require.NoError(t, err)
+	_, err = client.Create(context.Background())
+	require.ErrorContains(t, err, "Kernel API returned 307")
+	assert.False(t, redirected.Load())
+}
+
+func TestWaitRetriesTransientStatusFailures(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(response, `{"message":"try again"}`, http.StatusServiceUnavailable)
+			return
+		}
+		fmt.Fprint(response, `{"id":"imp_1","phase":"completed"}`)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "token", "")
+	require.NoError(t, err)
+	status, err := client.Wait(context.Background(), "imp_1", time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", status.Phase)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
+func TestWaitFailsPermanentStatusErrorImmediately(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(response, `{"message":"not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "token", "")
+	require.NoError(t, err)
+	_, err = client.Wait(context.Background(), "imp_1", time.Millisecond)
+	require.ErrorContains(t, err, "404")
+	assert.EqualValues(t, 1, calls.Load())
+}

--- a/internal/browserimport/client_test.go
+++ b/internal/browserimport/client_test.go
@@ -54,7 +54,7 @@ func TestClientRunsBrowserImportLifecycleWithScopedTokens(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.SubmitInventory(context.Background(), created.ID, created.HelperToken, Inventory{Sources: []Source{{ID: "chrome", Kind: "browser", Name: "Chrome", DataTypes: []string{"cookies"}}}})
 	require.NoError(t, err)
-	_, err = client.SubmitSelection(context.Background(), created.ID, Selection{Profiles: []ProfileSelection{}, CredentialSources: []string{}})
+	_, err = client.SubmitSelection(context.Background(), created.ID, Selection{Profiles: []ProfileSelection{}})
 	require.NoError(t, err)
 	_, err = client.Upload(context.Background(), created.ID, created.HelperToken, []byte("bundle"))
 	require.NoError(t, err)

--- a/internal/browserimport/types.go
+++ b/internal/browserimport/types.go
@@ -1,0 +1,103 @@
+package browserimport
+
+import "time"
+
+const BundleVersion = 1
+
+type Browser struct {
+	ID       string
+	Name     string
+	Root     string
+	Keychain KeychainIdentity
+}
+
+type KeychainIdentity struct {
+	Service string
+	Account string
+}
+
+type Profile struct {
+	ID      string
+	Name    string
+	Browser Browser
+	Path    string
+}
+
+func (p Profile) DisplayName() string {
+	return p.Browser.Name + " / " + p.Name
+}
+
+type Site struct {
+	Domain      string
+	Visits      int
+	LastVisited time.Time
+	CookieCount int
+}
+
+type Cookie struct {
+	Domain    string     `json:"domain"`
+	Path      string     `json:"path"`
+	Name      string     `json:"name"`
+	Value     string     `json:"value"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	HTTPOnly  bool       `json:"http_only,omitempty"`
+	Secure    bool       `json:"secure,omitempty"`
+	SameSite  string     `json:"same_site,omitempty"`
+}
+
+type Source struct {
+	ID         string         `json:"id"`
+	Kind       string         `json:"kind"`
+	Name       string         `json:"name"`
+	Browser    string         `json:"browser,omitempty"`
+	DataTypes  []string       `json:"data_types"`
+	ItemCounts map[string]int `json:"item_counts,omitempty"`
+}
+
+type Inventory struct {
+	Sources []Source `json:"sources"`
+}
+
+type ProfileSelection struct {
+	SourceID   string   `json:"source_id"`
+	TargetName string   `json:"target_name"`
+	Categories []string `json:"categories"`
+}
+
+type Selection struct {
+	Profiles          []ProfileSelection `json:"profiles"`
+	CredentialSources []string           `json:"credential_sources"`
+}
+
+type AppliedProfile struct {
+	SourceID   string `json:"source_id"`
+	ProfileID  string `json:"profile_id"`
+	TargetName string `json:"target_name"`
+}
+
+type ApplyFailure struct {
+	SourceID string `json:"source_id,omitempty"`
+	Stage    string `json:"stage"`
+	Message  string `json:"message"`
+}
+
+type Applied struct {
+	Profiles            []AppliedProfile `json:"profiles"`
+	CredentialsImported int              `json:"credentials_imported"`
+	ExtensionsDetected  int              `json:"extensions_detected"`
+	Failure             *ApplyFailure    `json:"failure,omitempty"`
+}
+
+type Status struct {
+	ID        string     `json:"id"`
+	Phase     string     `json:"phase"`
+	Inventory *Inventory `json:"inventory,omitempty"`
+	Selection *Selection `json:"selection,omitempty"`
+	Applied   *Applied   `json:"applied,omitempty"`
+}
+
+type CreateResponse struct {
+	ID                   string    `json:"id"`
+	HelperToken          string    `json:"helper_token"`
+	HelperTokenExpiresAt time.Time `json:"helper_token_expires_at"`
+}

--- a/internal/browserimport/types.go
+++ b/internal/browserimport/types.go
@@ -66,8 +66,7 @@ type ProfileSelection struct {
 }
 
 type Selection struct {
-	Profiles          []ProfileSelection `json:"profiles"`
-	CredentialSources []string           `json:"credential_sources"`
+	Profiles []ProfileSelection `json:"profiles"`
 }
 
 type AppliedProfile struct {

--- a/internal/browserimport/types.go
+++ b/internal/browserimport/types.go
@@ -17,10 +17,11 @@ type KeychainIdentity struct {
 }
 
 type Profile struct {
-	ID      string
-	Name    string
-	Browser Browser
-	Path    string
+	ID        string
+	Name      string
+	Browser   Browser
+	Path      string
+	Directory string
 }
 
 func (p Profile) DisplayName() string {

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -12,45 +12,42 @@ import (
 
 // GetAuthenticatedClient returns a Kernel client with appropriate authentication
 func GetAuthenticatedClient(opts ...option.RequestOption) (*kernel.Client, error) {
-	// Try to use API key first if available
-	apiKey := os.Getenv("KERNEL_API_KEY")
-	if apiKey != "" {
+	token, err := BearerToken(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	authOpts := append(opts, option.WithHeader("Authorization", "Bearer "+token))
+	client := kernel.NewClient(authOpts...)
+	return &client, nil
+}
+
+// BearerToken returns the same refreshed API key or OAuth token used by the
+// generated SDK. Commands that call an API endpoint not yet present in the
+// released SDK use this narrow accessor instead of implementing auth twice.
+func BearerToken(ctx context.Context) (string, error) {
+	if apiKey := os.Getenv("KERNEL_API_KEY"); apiKey != "" {
 		pterm.Debug.Println("Using API key authentication")
-
-		authOpts := append(opts, option.WithHeader("Authorization", "Bearer "+apiKey))
-		client := kernel.NewClient(authOpts...)
-		return &client, nil
+		return apiKey, nil
 	}
 
-	// Fallback to OAuth tokens if no API key is available
 	tokens, err := LoadTokens()
-	if err == nil {
-		// Check if access token is expired and refresh if needed
-		if tokens.IsExpired() && tokens.RefreshToken != "" {
-			pterm.Debug.Println("Access token expired, attempting refresh...")
-
-			refreshedTokens, refreshErr := RefreshTokens(context.Background(), tokens)
-			if refreshErr != nil {
-				pterm.Warning.Printf("Failed to refresh tokens: %v\n", refreshErr)
-				pterm.Info.Println("Please run 'kernel login' to re-authenticate")
-				return nil, fmt.Errorf("expired credentials, please re-authenticate: %w", refreshErr)
-			}
-
-			// Save refreshed tokens
-			if saveErr := SaveTokens(refreshedTokens); saveErr != nil {
-				pterm.Warning.Printf("Failed to save refreshed tokens: %v\n", saveErr)
-			}
-
-			tokens = refreshedTokens
-			pterm.Debug.Println("Successfully refreshed access token")
-		}
-
-		// Use JWT token for authentication via Authorization header
-		authOpts := append(opts, option.WithHeader("Authorization", "Bearer "+tokens.AccessToken))
-		client := kernel.NewClient(authOpts...)
-		return &client, nil
+	if err != nil {
+		return "", fmt.Errorf("no authentication available. Please run 'kernel login' or set KERNEL_API_KEY environment variable")
+	}
+	if !tokens.IsExpired() || tokens.RefreshToken == "" {
+		return tokens.AccessToken, nil
 	}
 
-	// No authentication available
-	return nil, fmt.Errorf("no authentication available. Please run 'kernel login' or set KERNEL_API_KEY environment variable")
+	pterm.Debug.Println("Access token expired, attempting refresh...")
+	refreshedTokens, refreshErr := RefreshTokens(ctx, tokens)
+	if refreshErr != nil {
+		pterm.Warning.Printf("Failed to refresh tokens: %v\n", refreshErr)
+		pterm.Info.Println("Please run 'kernel login' to re-authenticate")
+		return "", fmt.Errorf("expired credentials, please re-authenticate: %w", refreshErr)
+	}
+	if saveErr := SaveTokens(refreshedTokens); saveErr != nil {
+		pterm.Warning.Printf("Failed to save credentials: %v\n", saveErr)
+	}
+	pterm.Debug.Println("Successfully refreshed access token")
+	return refreshedTokens.AccessToken, nil
 }

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -172,6 +172,20 @@ func (p Prompter) Select(what, hint, promptText string, options []string) (strin
 		Show()
 }
 
+// MultiSelect shows a checkbox menu and returns the selected options.
+func (p Prompter) MultiSelect(what, hint, promptText string, options, defaults []string) ([]string, error) {
+	if !p.CanPrompt() {
+		return nil, ErrInputRequired(what, hint)
+	}
+	return pterm.DefaultInteractiveMultiselect.
+		WithOptions(options).
+		WithDefaultOptions(defaults).
+		WithDefaultText(promptText).
+		WithFilter(true).
+		WithMaxHeight(min(len(options), 12)).
+		Show()
+}
+
 // TextInput shows a free-text prompt and returns the entered text. When the
 // Prompter cannot prompt it fails fast with ErrInputRequired(what, hint)
 // instead.

--- a/pkg/interactive/interactive_test.go
+++ b/pkg/interactive/interactive_test.go
@@ -100,6 +100,11 @@ func TestPromptPrimitivesFailFastWhenNonInteractive(t *testing.T) {
 	assert.Contains(t, err.Error(), "widget selection")
 	assert.Contains(t, err.Error(), "pass --widget")
 
+	_, err = p.MultiSelect("websites", "pass --sites", "Choose websites", []string{"example.com"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "websites")
+	assert.Contains(t, err.Error(), "pass --sites")
+
 	_, err = p.TextInput("widget name", "pass --name", "Name?")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "widget name")


### PR DESCRIPTION
## why

The browser-import backend stack currently assumes a separate local helper and dashboard handoff. Kernel already ships a cross-platform CLI with authentication, project selection, upgrades, prompts, and release distribution. Putting the local import entry point there removes a second installer and makes the happy path one command.

This PR intentionally supports only the current main path: Google Chrome and Helium on macOS, importing cookies for five to ten recently used websites into one Kernel profile.

## what

- add `kernel profiles import-local`
- discover local Google Chrome and Helium profiles on macOS
- rank websites using visits from the last 30 days
- preselect the five most-used sites and allow up to ten
- show the selected domains, visit counts, and cookie counts before upload
- decrypt only cookies belonging to selected sites through macOS Keychain
- exclude partitioned Chromium cookies until the portable contract supports partition keys
- upload a minimal versioned bundle through the existing durable browser-import workflow
- reuse the CLI's API-key or refreshed OAuth authentication
- support explicit flags for deterministic non-interactive use

## how

The command reads Chrome's local History and Cookies SQLite databases through the system sqlite3 client. It groups history by registrable domain, filters cookies locally, and encodes only selected cookie records into the server's existing tar.zst bundle contract.

The released Go SDK does not yet expose the browser-import endpoints, so this PR includes a narrow authenticated HTTP client for those four endpoints. Managed Auth and credential creation remain on the existing generated SDK and are intentionally deferred to the next stacked PR.

## scope

Included:

- macOS
- Google Chrome
- Helium
- recent-site selection
- cookies
- one Kernel profile

Not included:

- Firefox, Zen, Safari, Windows, or Linux
- browser-native passwords
- password managers or Managed Auth activation
- extensions, themes, bookmarks, or full history transfer
- a daemon, custom URL scheme, native app, or browser extension

## verification

Before: the Kernel CLI had no local browser import command. Browser import required the dashboard and standalone helper path.

After:

- `make build` passes
- `make test` passes, including `go vet ./...` and `go test ./...`
- contract test covers create, inventory, selection, bundle upload, and status polling with the correct user/helper token boundary
- bundle test verifies manifest-first tar.zst output and normalized cookie JSONL
- profile discovery tests cover Chrome and Helium
- site-selection tests cover defaults, explicit domains, deduplication, and non-interactive failure behavior
- untrusted plaintext API hosts are rejected while HTTPS and localhost development remain supported

This is the first PR in the CLI browser-import stack. The next PR adds selected Bitwarden/1Password credentials, Managed Auth activation, and optional agent-skill installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Reads and decrypts browser cookies from local Chromium databases and Keychain, then uploads session material to the API. Auth token handling is also refactored for a custom HTTP client.
> 
> **Overview**
> Adds `kernel profiles import-local` so macOS users can pull cookies from local Google Chrome or Helium into a Kernel profile without a separate helper.
> 
> The command discovers profiles, ranks recent sites from History, decrypts only selected-site cookies via Keychain, and uploads a tar.zst cookie bundle through the browser-import API. `import-status` polls that job. Interactive site/profile prompts are skippable with `--sites` / `--yes`.
> 
> Also extracts `auth.BearerToken` for endpoints not in the released SDK, and adds a narrow HTTP client that rejects untrusted API URLs and does not follow redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d3c5b7047af76cd0e0d610d0cac47776f745a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->