### PR TITLE
Import selected logins into Managed Auth

### DIFF
--- a/cmd/browser_import_managed_auth.go
+++ b/cmd/browser_import_managed_auth.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/kernel/cli/internal/passwordmanager"
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
+)
+
+type managedAuthProvisioner interface {
+	Provision(context.Context, string, []passwordmanager.Record) ([]string, error)
+}
+
+type kernelManagedAuthProvisioner struct {
+	credentials interface {
+		New(context.Context, kernel.CredentialNewParams, ...option.RequestOption) (*kernel.Credential, error)
+		Get(context.Context, string, ...option.RequestOption) (*kernel.Credential, error)
+		Update(context.Context, string, kernel.CredentialUpdateParams, ...option.RequestOption) (*kernel.Credential, error)
+	}
+	connections interface {
+		New(context.Context, kernel.AuthConnectionNewParams, ...option.RequestOption) (*kernel.ManagedAuth, error)
+		List(context.Context, kernel.AuthConnectionListParams, ...option.RequestOption) (*pagination.OffsetPagination[kernel.ManagedAuth], error)
+	}
+}
+
+func (p kernelManagedAuthProvisioner) Provision(ctx context.Context, profileName string, records []passwordmanager.Record) ([]string, error) {
+	connectionIDs := make([]string, 0, len(records))
+	for _, record := range records {
+		name := importedCredentialName(record)
+		existing, err := p.findConnection(ctx, profileName, record.Domain, name)
+		if err != nil {
+			return connectionIDs, fmt.Errorf("check managed auth for %s: %w", record.Domain, err)
+		}
+		if existing.match != nil {
+			if err := p.refreshCredential(ctx, name, record); err != nil {
+				return connectionIDs, err
+			}
+			connectionIDs = append(connectionIDs, existing.match.ID)
+			continue
+		}
+		if existing.conflict != nil {
+			return connectionIDs, fmt.Errorf("managed auth for %s already uses credential %q", record.Domain, existing.conflict.Credential.Name)
+		}
+
+		values := map[string]string{"username": record.Username, "password": record.Password}
+		credentialParams := kernel.CredentialNewParams{CreateCredentialRequest: kernel.CreateCredentialRequestParam{Name: name, Domain: record.Domain, Values: values}}
+		if record.TOTPSecret != "" {
+			credentialParams.CreateCredentialRequest.TotpSecret = kernel.Opt(record.TOTPSecret)
+		}
+		credential, err := p.credentials.New(ctx, credentialParams)
+		if err != nil {
+			var getErr error
+			credential, getErr = p.credentials.Get(ctx, name)
+			if getErr != nil || credential == nil {
+				return connectionIDs, fmt.Errorf("create credential for %s: %w", record.Domain, err)
+			}
+			if err := p.refreshCredential(ctx, name, record); err != nil {
+				return connectionIDs, err
+			}
+		}
+		connection, err := p.connections.New(ctx, kernel.AuthConnectionNewParams{ManagedAuthCreateRequest: kernel.ManagedAuthCreateRequestParam{
+			Domain: record.Domain, ProfileName: profileName,
+			Credential: kernel.ManagedAuthCreateRequestCredentialParam{Name: kernel.Opt(name)},
+		}})
+		if err != nil {
+			reconciled, listErr := p.findConnection(ctx, profileName, record.Domain, name)
+			if listErr == nil && reconciled.match != nil {
+				connectionIDs = append(connectionIDs, reconciled.match.ID)
+				continue
+			}
+			return connectionIDs, fmt.Errorf("create managed auth for %s: %w", record.Domain, err)
+		}
+		connectionIDs = append(connectionIDs, connection.ID)
+	}
+	return connectionIDs, nil
+}
+
+type connectionLookup struct {
+	match    *kernel.ManagedAuth
+	conflict *kernel.ManagedAuth
+}
+
+func (p kernelManagedAuthProvisioner) findConnection(ctx context.Context, profileName, domain, credentialName string) (connectionLookup, error) {
+	const pageSize = 100
+	result := connectionLookup{}
+	for offset := int64(0); ; offset += pageSize {
+		page, err := p.connections.List(ctx, kernel.AuthConnectionListParams{
+			Domain: kernel.Opt(domain), ProfileName: kernel.Opt(profileName), Limit: kernel.Opt(int64(pageSize)), Offset: kernel.Opt(offset),
+		})
+		if err != nil {
+			return connectionLookup{}, err
+		}
+		if page == nil {
+			return result, nil
+		}
+		for index := range page.Items {
+			connection := &page.Items[index]
+			if connection.Credential.Name == credentialName {
+				copy := *connection
+				result.match = &copy
+			} else if result.conflict == nil {
+				copy := *connection
+				result.conflict = &copy
+			}
+		}
+		if len(page.Items) < pageSize {
+			return result, nil
+		}
+	}
+}
+
+func (p kernelManagedAuthProvisioner) refreshCredential(ctx context.Context, name string, record passwordmanager.Record) error {
+	update := kernel.CredentialUpdateParams{UpdateCredentialRequest: kernel.UpdateCredentialRequestParam{
+		Values:     map[string]string{"username": record.Username, "password": record.Password},
+		TotpSecret: kernel.Opt(record.TOTPSecret),
+	}}
+	if _, err := p.credentials.Update(ctx, name, update); err != nil {
+		return fmt.Errorf("refresh credential for %s: %w", record.Domain, err)
+	}
+	return nil
+}
+
+var importedCredentialCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func importedCredentialName(record passwordmanager.Record) string {
+	digest := sha256.Sum256([]byte(record.Provider + "\x00" + record.ID))
+	prefix := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower("import-"+record.Provider), "-"), "-")
+	domain := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower(record.Domain), "-"), "-")
+	suffix := fmt.Sprintf("-%x", digest[:5])
+	maxDomainLength := 255 - len(prefix) - len(suffix) - 1
+	if len(domain) > maxDomainLength {
+		domain = strings.Trim(domain[:maxDomainLength], "-")
+	}
+	return prefix + "-" + domain + suffix
+}

--- a/cmd/browser_import_managed_auth_test.go
+++ b/cmd/browser_import_managed_auth_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kernel/cli/internal/passwordmanager"
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeImportedCredentials struct {
+	newFunc    func(kernel.CredentialNewParams) (*kernel.Credential, error)
+	getFunc    func(string) (*kernel.Credential, error)
+	updateFunc func(string, kernel.CredentialUpdateParams) (*kernel.Credential, error)
+}
+
+func (f fakeImportedCredentials) New(_ context.Context, params kernel.CredentialNewParams, _ ...option.RequestOption) (*kernel.Credential, error) {
+	return f.newFunc(params)
+}
+
+func (f fakeImportedCredentials) Get(_ context.Context, name string, _ ...option.RequestOption) (*kernel.Credential, error) {
+	return f.getFunc(name)
+}
+
+func (f fakeImportedCredentials) Update(_ context.Context, name string, params kernel.CredentialUpdateParams, _ ...option.RequestOption) (*kernel.Credential, error) {
+	return f.updateFunc(name, params)
+}
+
+type fakeImportedConnections struct {
+	newFunc  func(kernel.AuthConnectionNewParams) (*kernel.ManagedAuth, error)
+	listFunc func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error)
+}
+
+func (f fakeImportedConnections) New(_ context.Context, params kernel.AuthConnectionNewParams, _ ...option.RequestOption) (*kernel.ManagedAuth, error) {
+	return f.newFunc(params)
+}
+
+func (f fakeImportedConnections) List(_ context.Context, params kernel.AuthConnectionListParams, _ ...option.RequestOption) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+	return f.listFunc(params)
+}
+
+func TestManagedAuthProvisionFreshPathUsesThreeRequests(t *testing.T) {
+	calls := make([]string, 0, 3)
+	provisioner := kernelManagedAuthProvisioner{
+		credentials: fakeImportedCredentials{
+			newFunc: func(params kernel.CredentialNewParams) (*kernel.Credential, error) {
+				calls = append(calls, "credential.new")
+				return &kernel.Credential{Name: params.CreateCredentialRequest.Name}, nil
+			},
+			getFunc: func(string) (*kernel.Credential, error) { t.Fatal("unexpected credential get"); return nil, nil },
+			updateFunc: func(string, kernel.CredentialUpdateParams) (*kernel.Credential, error) {
+				t.Fatal("unexpected credential update")
+				return nil, nil
+			},
+		},
+		connections: fakeImportedConnections{
+			listFunc: func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+				calls = append(calls, "connection.list")
+				return &pagination.OffsetPagination[kernel.ManagedAuth]{Items: []kernel.ManagedAuth{}}, nil
+			},
+			newFunc: func(kernel.AuthConnectionNewParams) (*kernel.ManagedAuth, error) {
+				calls = append(calls, "connection.new")
+				return &kernel.ManagedAuth{ID: "auth_1"}, nil
+			},
+		},
+	}
+
+	ids, err := provisioner.Provision(t.Context(), "imported", []passwordmanager.Record{{Provider: "bitwarden", ID: "item", Domain: "example.com", Username: "me", Password: "secret"}})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"auth_1"}, ids)
+	assert.Equal(t, []string{"connection.list", "credential.new", "connection.new"}, calls)
+}
+
+func TestManagedAuthProvisionRetryRefreshesCredentialAndRemovesTOTP(t *testing.T) {
+	record := passwordmanager.Record{Provider: "bitwarden", ID: "item", Domain: "example.com", Username: "me", Password: "new"}
+	name := importedCredentialName(record)
+	var update kernel.CredentialUpdateParams
+	provisioner := kernelManagedAuthProvisioner{
+		credentials: fakeImportedCredentials{
+			newFunc: func(kernel.CredentialNewParams) (*kernel.Credential, error) {
+				t.Fatal("unexpected credential create")
+				return nil, nil
+			},
+			getFunc: func(string) (*kernel.Credential, error) { t.Fatal("unexpected credential get"); return nil, nil },
+			updateFunc: func(_ string, params kernel.CredentialUpdateParams) (*kernel.Credential, error) {
+				update = params
+				return &kernel.Credential{Name: name}, nil
+			},
+		},
+		connections: fakeImportedConnections{
+			listFunc: func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+				return &pagination.OffsetPagination[kernel.ManagedAuth]{Items: []kernel.ManagedAuth{{ID: "auth_existing", Credential: kernel.ManagedAuthCredential{Name: name}}}}, nil
+			},
+			newFunc: func(kernel.AuthConnectionNewParams) (*kernel.ManagedAuth, error) {
+				t.Fatal("unexpected connection create")
+				return nil, nil
+			},
+		},
+	}
+
+	ids, err := provisioner.Provision(t.Context(), "imported", []passwordmanager.Record{record})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"auth_existing"}, ids)
+	require.True(t, update.UpdateCredentialRequest.TotpSecret.Valid())
+	assert.Empty(t, update.UpdateCredentialRequest.TotpSecret.Value)
+}
+
+func TestManagedAuthProvisionDoesNotMutateCredentialOnConnectionConflict(t *testing.T) {
+	provisioner := kernelManagedAuthProvisioner{
+		credentials: fakeImportedCredentials{
+			newFunc: func(kernel.CredentialNewParams) (*kernel.Credential, error) {
+				t.Fatal("unexpected credential create")
+				return nil, nil
+			},
+			getFunc: func(string) (*kernel.Credential, error) { t.Fatal("unexpected credential get"); return nil, nil },
+			updateFunc: func(string, kernel.CredentialUpdateParams) (*kernel.Credential, error) {
+				t.Fatal("unexpected credential update")
+				return nil, nil
+			},
+		},
+		connections: fakeImportedConnections{
+			listFunc: func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+				return &pagination.OffsetPagination[kernel.ManagedAuth]{Items: []kernel.ManagedAuth{{ID: "auth_other", Credential: kernel.ManagedAuthCredential{Name: "user-owned"}}}}, nil
+			},
+			newFunc: func(kernel.AuthConnectionNewParams) (*kernel.ManagedAuth, error) {
+				return nil, errors.New("unexpected connection create")
+			},
+		},
+	}
+
+	_, err := provisioner.Provision(t.Context(), "imported", []passwordmanager.Record{{Provider: "bitwarden", ID: "item", Domain: "example.com"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `already uses credential "user-owned"`)
+}
+
+func TestImportedCredentialNameFitsAPINameLimit(t *testing.T) {
+	name := importedCredentialName(passwordmanager.Record{Provider: "bitwarden", ID: "item", Domain: strings.Repeat("a", 253)})
+	assert.LessOrEqual(t, len(name), 255)
+	assert.Contains(t, name, "import-bitwarden-")
+	assert.Regexp(t, `-[a-f0-9]{10}$`, name)
+}
+
+func TestManagedAuthProvisionFindsMatchingConnectionAfterSiblingAccount(t *testing.T) {
+	record := passwordmanager.Record{Provider: "bitwarden", ID: "item", Domain: "example.com", Username: "me"}
+	name := importedCredentialName(record)
+	updated := false
+	provisioner := kernelManagedAuthProvisioner{
+		credentials: fakeImportedCredentials{
+			newFunc: func(kernel.CredentialNewParams) (*kernel.Credential, error) {
+				t.Fatal("unexpected credential create")
+				return nil, nil
+			},
+			getFunc: func(string) (*kernel.Credential, error) { t.Fatal("unexpected credential get"); return nil, nil },
+			updateFunc: func(string, kernel.CredentialUpdateParams) (*kernel.Credential, error) {
+				updated = true
+				return &kernel.Credential{Name: name}, nil
+			},
+		},
+		connections: fakeImportedConnections{
+			listFunc: func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+				return &pagination.OffsetPagination[kernel.ManagedAuth]{Items: []kernel.ManagedAuth{
+					{ID: "auth_other", Credential: kernel.ManagedAuthCredential{Name: "another-account"}},
+					{ID: "auth_match", Credential: kernel.ManagedAuthCredential{Name: name}},
+				}}, nil
+			},
+			newFunc: func(kernel.AuthConnectionNewParams) (*kernel.ManagedAuth, error) {
+				t.Fatal("unexpected connection create")
+				return nil, nil
+			},
+		},
+	}
+
+	ids, err := provisioner.Provision(t.Context(), "imported", []passwordmanager.Record{record})
+	require.NoError(t, err)
+	assert.True(t, updated)
+	assert.Equal(t, []string{"auth_match"}, ids)
+}

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -50,8 +50,17 @@ type ProfilesImportLocalCmd struct {
 }
 
 type pendingManagedAuth struct {
+	providers []pendingProviderLogins
+}
+
+type pendingProviderLogins struct {
 	provider   passwordmanager.Provider
 	candidates []passwordmanager.Candidate
+}
+
+type sourcedPasswordManagerCandidate struct {
+	provider  passwordmanager.Provider
+	candidate passwordmanager.Candidate
 }
 
 func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
@@ -229,13 +238,16 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	profileID := status.Applied.Profiles[0].ProfileID
 	connectionIDs := make([]string, 0)
 	approvedLogins := make([]passwordmanager.Record, 0)
-	if pendingLogins.provider != nil && len(pendingLogins.candidates) > 0 {
+	if len(pendingLogins.providers) > 0 {
 		phaseStarted = time.Now()
-		approvedLogins, err = pendingLogins.provider.Reveal(ctx, pendingLogins.candidates)
-		timings["password_manager_reveal"] = time.Since(phaseStarted)
-		if err != nil {
-			return fmt.Errorf("profile %s is ready, but approved password-manager items could not be read: %w", targetName, err)
+		for _, pendingProvider := range pendingLogins.providers {
+			records, revealErr := pendingProvider.provider.Reveal(ctx, pendingProvider.candidates)
+			if revealErr != nil {
+				return fmt.Errorf("profile %s is ready, but approved %s items could not be read: %w", targetName, pendingProvider.provider.Name(), revealErr)
+			}
+			approvedLogins = append(approvedLogins, records...)
 		}
+		timings["password_manager_reveal"] = time.Since(phaseStarted)
 	}
 	if len(approvedLogins) > 0 {
 		if c.provisioner == nil {
@@ -331,7 +343,7 @@ func (c ProfilesImportLocalCmd) offerAgentSkills(home string, installRequested, 
 }
 
 func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sites []string, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
-	if requested == "none" || (requested == "" && nonInteractive) {
+	if strings.EqualFold(strings.TrimSpace(requested), "none") || (requested == "" && nonInteractive) {
 		return pendingManagedAuth{}, nil
 	}
 	if c.providers == nil {
@@ -347,84 +359,107 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 		}
 		return pendingManagedAuth{}, nil
 	}
-	chosen := requested
-	if chosen == "" {
-		options := []string{"Skip passwords for now"}
+	chosenProviders := make([]passwordmanager.Provider, 0, len(providers))
+	if requested == "" {
+		options := make([]string, 0, len(providers))
+		byName := make(map[string]passwordmanager.Provider, len(providers))
 		for _, provider := range providers {
 			options = append(options, provider.Name())
+			byName[provider.Name()] = provider
 		}
-		selection, err := c.prompter.Select("password manager", "pass --password-manager", "Bring matching logins into Managed Auth?", options)
+		selected, err := c.prompter.MultiSelect("password managers", "pass --password-manager", "Choose password managers to search", options, options)
 		if err != nil {
 			return pendingManagedAuth{}, err
 		}
-		if selection == options[0] {
-			return pendingManagedAuth{}, nil
+		for _, name := range selected {
+			chosenProviders = append(chosenProviders, byName[name])
 		}
-		chosen = strings.ToLower(strings.ReplaceAll(selection, "Password", "password"))
-	}
-	var provider passwordmanager.Provider
-	for _, candidate := range providers {
-		id := strings.ToLower(strings.ReplaceAll(candidate.Name(), "Password", "password"))
-		if strings.EqualFold(chosen, id) || (chosen == "1password" && candidate.Name() == "1Password") || (chosen == "bitwarden" && candidate.Name() == "Bitwarden") {
-			provider = candidate
-			break
-		}
-	}
-	if provider == nil {
-		return pendingManagedAuth{}, fmt.Errorf("password manager %q is unavailable; use bitwarden, 1password, or none", requested)
-	}
-	if authorizer, ok := provider.(passwordmanager.InteractiveAuthorizer); ok {
-		required, err := authorizer.AuthorizationRequired(ctx)
-		if err != nil {
-			return pendingManagedAuth{}, err
-		}
-		if required {
-			if nonInteractive {
-				return pendingManagedAuth{}, fmt.Errorf("Bitwarden is locked; unlock it with `export BW_SESSION=$(bw unlock --raw)`, then retry")
-			}
-			approved, err := c.prompter.Confirm("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?")
-			if err != nil {
-				return pendingManagedAuth{}, err
-			}
-			if !approved {
-				return pendingManagedAuth{}, nil
-			}
-			if err := authorizer.Authorize(ctx); err != nil {
-				return pendingManagedAuth{}, err
-			}
-			if humanOutput {
-				pterm.Success.Println("Bitwarden unlocked for this import")
+	} else {
+		requestedNames := strings.Split(requested, ",")
+		if strings.EqualFold(strings.TrimSpace(requested), "all") {
+			chosenProviders = append(chosenProviders, providers...)
+		} else {
+			for _, name := range requestedNames {
+				provider := findPasswordManager(providers, strings.TrimSpace(name))
+				if provider == nil {
+					return pendingManagedAuth{}, fmt.Errorf("password manager %q is unavailable; use bitwarden, 1password, all, or none", strings.TrimSpace(name))
+				}
+				chosenProviders = append(chosenProviders, provider)
 			}
 		}
 	}
-	if humanOutput {
-		pterm.Info.Printf("Find matching %s logins...\n", provider.Name())
-	}
-	candidates, err := provider.Candidates(ctx, sites)
-	if err != nil {
-		return pendingManagedAuth{}, err
-	}
-	if len(candidates) == 0 {
-		if humanOutput {
-			pterm.Info.Printf("No %s logins matched the selected websites\n", provider.Name())
-		}
+	if len(chosenProviders) == 0 {
 		return pendingManagedAuth{}, nil
 	}
-	labels := make([]string, 0, len(candidates))
-	byLabel := make(map[string]passwordmanager.Candidate, len(candidates))
+	chosenProviders = deduplicatePasswordManagers(chosenProviders)
+	allCandidates := make([]sourcedPasswordManagerCandidate, 0)
+	for _, provider := range chosenProviders {
+		if authorizer, ok := provider.(passwordmanager.InteractiveAuthorizer); ok {
+			required, err := authorizer.AuthorizationRequired(ctx)
+			if err != nil {
+				if nonInteractive {
+					return pendingManagedAuth{}, err
+				}
+				if humanOutput {
+					pterm.Warning.Printf("Skipping %s: %v\n", provider.Name(), err)
+				}
+				continue
+			}
+			if required {
+				if nonInteractive {
+					return pendingManagedAuth{}, fmt.Errorf("Bitwarden is locked; unlock it with `export BW_SESSION=$(bw unlock --raw)`, then retry")
+				}
+				approved, err := c.prompter.Confirm("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?")
+				if err != nil {
+					return pendingManagedAuth{}, err
+				}
+				if !approved {
+					continue
+				}
+				if err := authorizer.Authorize(ctx); err != nil {
+					if humanOutput {
+						pterm.Warning.Printf("Skipping %s: %v\n", provider.Name(), err)
+					}
+					continue
+				}
+				if humanOutput {
+					pterm.Success.Println("Bitwarden unlocked for this import")
+				}
+			}
+		}
+		if humanOutput {
+			pterm.Info.Printf("Find matching %s logins...\n", provider.Name())
+		}
+		candidates, err := discoverProviderCandidates(ctx, provider, sites, nonInteractive, humanOutput)
+		if err != nil {
+			return pendingManagedAuth{}, err
+		}
+		if len(candidates) == 0 && humanOutput {
+			pterm.Info.Printf("No %s logins matched the selected websites\n", provider.Name())
+		}
+		for _, candidate := range candidates {
+			allCandidates = append(allCandidates, sourcedPasswordManagerCandidate{provider: provider, candidate: candidate})
+		}
+	}
+	if len(allCandidates) == 0 {
+		return pendingManagedAuth{}, nil
+	}
+	labels := make([]string, 0, len(allCandidates))
+	byLabel := make(map[string]sourcedPasswordManagerCandidate, len(allCandidates))
 	defaultLabels := make([]string, 0, len(sites))
 	domainCounts := make(map[string]int, len(sites))
-	for _, candidate := range candidates {
-		domainCounts[candidate.Domain]++
+	for _, sourced := range allCandidates {
+		domainCounts[sourced.candidate.Domain]++
 	}
-	for index, candidate := range candidates {
+	for index, sourced := range allCandidates {
+		candidate := sourced.candidate
 		idSuffix := candidate.ID
 		if len(idSuffix) > 6 {
 			idSuffix = idSuffix[len(idSuffix)-6:]
 		}
-		label := loginCandidateLabel(index, candidate, idSuffix)
+		label := loginCandidateLabel(index, sourced.provider.Name(), candidate, idSuffix)
 		labels = append(labels, label)
-		byLabel[label] = candidate
+		byLabel[label] = sourced
 		if domainCounts[candidate.Domain] == 1 {
 			defaultLabels = append(defaultLabels, label)
 		}
@@ -438,22 +473,89 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 	}
 	chosenLabels := defaultLabels
 	if !nonInteractive {
-		chosenLabels, err = c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", "Choose logins to create in Managed Auth", labels, defaultLabels)
-		if err != nil {
-			return pendingManagedAuth{}, err
+		for {
+			selected, promptErr := c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", "Choose at most one login per website", labels, chosenLabels)
+			if promptErr != nil {
+				return pendingManagedAuth{}, promptErr
+			}
+			if duplicateDomain := duplicateSelectedDomain(selected, byLabel); duplicateDomain != "" {
+				pterm.Warning.Printf("Choose only one login for %s; your selections are preserved\n", duplicateDomain)
+				chosenLabels = selected
+				continue
+			}
+			chosenLabels = selected
+			break
 		}
 	}
-	approved := make([]passwordmanager.Candidate, 0, len(chosenLabels))
+	approvedByProvider := make(map[string][]passwordmanager.Candidate, len(chosenProviders))
 	selectedDomains := make(map[string]struct{}, len(chosenLabels))
 	for _, label := range chosenLabels {
-		candidate := byLabel[label]
+		sourced := byLabel[label]
+		candidate := sourced.candidate
 		if _, exists := selectedDomains[candidate.Domain]; exists {
 			return pendingManagedAuth{}, fmt.Errorf("select at most one login for %s", candidate.Domain)
 		}
 		selectedDomains[candidate.Domain] = struct{}{}
-		approved = append(approved, candidate)
+		approvedByProvider[sourced.provider.Name()] = append(approvedByProvider[sourced.provider.Name()], candidate)
 	}
-	return pendingManagedAuth{provider: provider, candidates: approved}, nil
+	pending := pendingManagedAuth{providers: make([]pendingProviderLogins, 0, len(approvedByProvider))}
+	for _, provider := range chosenProviders {
+		if candidates := approvedByProvider[provider.Name()]; len(candidates) > 0 {
+			pending.providers = append(pending.providers, pendingProviderLogins{provider: provider, candidates: candidates})
+		}
+	}
+	return pending, nil
+}
+
+func discoverProviderCandidates(ctx context.Context, provider passwordmanager.Provider, sites []string, nonInteractive, humanOutput bool) ([]passwordmanager.Candidate, error) {
+	candidates, err := provider.Candidates(ctx, sites)
+	if err == nil {
+		return candidates, nil
+	}
+	if nonInteractive {
+		return nil, err
+	}
+	if humanOutput {
+		pterm.Warning.Printf("Skipping %s: %v\n", provider.Name(), err)
+	}
+	return nil, nil
+}
+
+func duplicateSelectedDomain(selected []string, candidates map[string]sourcedPasswordManagerCandidate) string {
+	seen := make(map[string]struct{}, len(selected))
+	for _, label := range selected {
+		domain := candidates[label].candidate.Domain
+		if _, exists := seen[domain]; exists {
+			return domain
+		}
+		seen[domain] = struct{}{}
+	}
+	return ""
+}
+
+func findPasswordManager(providers []passwordmanager.Provider, requested string) passwordmanager.Provider {
+	for _, provider := range providers {
+		if strings.EqualFold(requested, strings.ToLower(strings.ReplaceAll(provider.Name(), "Password", "password"))) ||
+			(strings.EqualFold(requested, "1password") && provider.Name() == "1Password") ||
+			(strings.EqualFold(requested, "bitwarden") && provider.Name() == "Bitwarden") {
+			return provider
+		}
+	}
+	return nil
+}
+
+func deduplicatePasswordManagers(providers []passwordmanager.Provider) []passwordmanager.Provider {
+	result := make([]passwordmanager.Provider, 0, len(providers))
+	seen := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		key := strings.ToLower(provider.Name())
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, provider)
+	}
+	return result
 }
 
 func browserImportProgressError(importID, phase string, elapsed time.Duration, err error) error {
@@ -661,7 +763,7 @@ func compactField(value string, limit int) string {
 	return ansi.Truncate(strings.Join(strings.Fields(value), " "), limit, "…")
 }
 
-func loginCandidateLabel(index int, candidate passwordmanager.Candidate, idSuffix string) string {
+func loginCandidateLabel(index int, provider string, candidate passwordmanager.Candidate, idSuffix string) string {
 	identity := candidate.Username
 	if identity == "" {
 		identity = "no username"
@@ -669,7 +771,17 @@ func loginCandidateLabel(index int, candidate passwordmanager.Candidate, idSuffi
 	indexLabel := fmt.Sprintf("%d", index+1)
 	indexWidth := max(2, ansi.StringWidth(indexLabel))
 	nameWidth := max(8, 16-(indexWidth-2))
-	return fmt.Sprintf("%*s  %s  %s  %s · %s", indexWidth, indexLabel, compactField(candidate.Domain, 18), compactField(identity, 20), compactField(candidate.Name, nameWidth), idSuffix)
+	return fmt.Sprintf("%*s  %s  %s  %s  %s · %s", indexWidth, indexLabel, passwordManagerAbbreviation(provider), compactField(candidate.Domain, 15), compactField(identity, 18), compactField(candidate.Name, nameWidth), idSuffix)
+}
+
+func passwordManagerAbbreviation(provider string) string {
+	if strings.EqualFold(provider, "Bitwarden") {
+		return "BW"
+	}
+	if strings.EqualFold(provider, "1Password") {
+		return "1P"
+	}
+	return compactField(provider, 2)
 }
 
 func projectOptionLabel(index int, project kernel.Project) string {
@@ -751,7 +863,7 @@ func init() {
 	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
 	profilesImportLocalCmd.Flags().Duration("wait-timeout", 30*time.Minute, "Maximum time to wait for the import to complete")
 	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
-	profilesImportLocalCmd.Flags().String("password-manager", "", "Import matching logins into Managed Auth: bitwarden, 1password, or none")
+	profilesImportLocalCmd.Flags().String("password-manager", "", "Password managers to search: bitwarden, 1password, both comma-separated, all, or none")
 	profilesImportLocalCmd.Flags().Bool("install-agent-skills", false, "Install the Kernel Managed Auth skill into detected agent directories")
 	addJSONOutputFlag(profilesImportLocalCmd)
 	addJSONOutputFlag(profilesImportStatusCmd)

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -409,7 +409,7 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 				if nonInteractive {
 					return pendingManagedAuth{}, fmt.Errorf("Bitwarden is locked; unlock it with `export BW_SESSION=$(bw unlock --raw)`, then retry")
 				}
-				approved, err := c.prompter.Confirm("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?")
+				approved, err := c.prompter.ConfirmDefault("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?", true)
 				if err != nil {
 					return pendingManagedAuth{}, err
 				}

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -10,13 +10,18 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/kernel/cli/internal/agentskills"
 	localbrowser "github.com/kernel/cli/internal/browserimport"
 	"github.com/kernel/cli/internal/passwordmanager"
 	"github.com/kernel/cli/pkg/auth"
 	"github.com/kernel/cli/pkg/interactive"
 	"github.com/kernel/cli/pkg/util"
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/param"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
@@ -417,7 +422,7 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 		if len(idSuffix) > 6 {
 			idSuffix = idSuffix[len(idSuffix)-6:]
 		}
-		label := fmt.Sprintf("%2d  %-28s %-28s %s · %s", index+1, candidate.Domain, candidate.Username, candidate.Name, idSuffix)
+		label := loginCandidateLabel(index, candidate, idSuffix)
 		labels = append(labels, label)
 		byLabel[label] = candidate
 		if domainCounts[candidate.Domain] == 1 {
@@ -642,6 +647,82 @@ func defaultImportedProfileName(profile localbrowser.Profile) string {
 	return name
 }
 
+func compactField(value string, limit int) string {
+	value = ansi.Strip(value)
+	value = strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return ' '
+		}
+		if !unicode.IsPrint(r) {
+			return -1
+		}
+		return r
+	}, value)
+	return ansi.Truncate(strings.Join(strings.Fields(value), " "), limit, "…")
+}
+
+func loginCandidateLabel(index int, candidate passwordmanager.Candidate, idSuffix string) string {
+	identity := candidate.Username
+	if identity == "" {
+		identity = "no username"
+	}
+	indexLabel := fmt.Sprintf("%d", index+1)
+	indexWidth := max(2, ansi.StringWidth(indexLabel))
+	nameWidth := max(8, 16-(indexWidth-2))
+	return fmt.Sprintf("%*s  %s  %s  %s · %s", indexWidth, indexLabel, compactField(candidate.Domain, 18), compactField(identity, 20), compactField(candidate.Name, nameWidth), idSuffix)
+}
+
+func projectOptionLabel(index int, project kernel.Project) string {
+	return fmt.Sprintf("%2d  %s", index+1, compactField(project.Name, 48))
+}
+
+func chooseImportProject(ctx context.Context, projects ProjectListService, prompter interactive.Prompter, requested string, nonInteractive bool) (string, error) {
+	if requested != "" {
+		return requested, nil
+	}
+	const pageSize int64 = 100
+	active := make([]kernel.Project, 0)
+	for offset := int64(0); ; {
+		page, err := projects.List(ctx, kernel.ProjectListParams{Limit: param.NewOpt(pageSize), Offset: param.NewOpt(offset)})
+		if err != nil {
+			return "", fmt.Errorf("list Kernel projects: %w", err)
+		}
+		if page == nil || len(page.Items) == 0 {
+			break
+		}
+		for _, project := range page.Items {
+			if project.Status == kernel.ProjectStatusActive {
+				active = append(active, project)
+			}
+		}
+		if int64(len(page.Items)) < pageSize {
+			break
+		}
+		offset += int64(len(page.Items))
+	}
+	if len(active) == 0 {
+		return "", fmt.Errorf("no active Kernel projects were found")
+	}
+	if len(active) == 1 {
+		return active[0].ID, nil
+	}
+	if nonInteractive {
+		return "", fmt.Errorf("multiple Kernel projects are available; pass --project")
+	}
+	options := make([]string, 0, len(active))
+	byOption := make(map[string]string, len(active))
+	for index, project := range active {
+		label := projectOptionLabel(index, project)
+		options = append(options, label)
+		byOption[label] = project.ID
+	}
+	chosen, err := prompter.Select("Kernel project", "pass --project", "Choose the Kernel project for this import", options)
+	if err != nil {
+		return "", err
+	}
+	return byOption[chosen], nil
+}
+
 var profileIDNameCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 var cuidLikeProfileName = regexp.MustCompile(`^[a-z0-9]{24}$`)
 
@@ -690,8 +771,19 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	project, _ := cmd.Flags().GetString("project")
 	project = resolveProjectSelection(project)
 	client := getKernelClient(cmd)
-	credentials := client.Credentials
-	connections := client.Auth.Connections
+	project, err := chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), project, skipConfirm || output == "json")
+	if err != nil {
+		return err
+	}
+	projectClient, err := auth.GetAuthenticatedClient(
+		option.WithProjectID(project),
+		option.WithHeader("X-Kernel-Cli-Version", metadata.Version),
+	)
+	if err != nil {
+		return fmt.Errorf("create project-scoped client: %w", err)
+	}
+	credentials := projectClient.Credentials
+	connections := projectClient.Auth.Connections
 	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter(), providers: passwordmanager.Detect, provisioner: kernelManagedAuthProvisioner{credentials: &credentials, connections: &connections}}
 	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version, WaitTimeout: waitTimeout, PasswordManager: passwordManager, InstallAgentSkills: installAgentSkills})
 }

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kernel/cli/internal/agentskills"
 	localbrowser "github.com/kernel/cli/internal/browserimport"
+	"github.com/kernel/cli/internal/passwordmanager"
 	"github.com/kernel/cli/pkg/auth"
 	"github.com/kernel/cli/pkg/interactive"
 	"github.com/kernel/cli/pkg/util"
@@ -20,22 +22,31 @@ import (
 )
 
 type ProfilesImportLocalInput struct {
-	BrowserProfile string
-	ProfileName    string
-	Sites          []string
-	Count          int
-	Days           int
-	SkipConfirm    bool
-	Output         string
-	ProjectID      string
-	Version        string
-	WaitTimeout    time.Duration
+	BrowserProfile     string
+	ProfileName        string
+	Sites              []string
+	Count              int
+	Days               int
+	SkipConfirm        bool
+	Output             string
+	ProjectID          string
+	Version            string
+	WaitTimeout        time.Duration
+	PasswordManager    string
+	InstallAgentSkills bool
 }
 
 type ProfilesImportLocalCmd struct {
-	prompter interactive.Prompter
-	homeDir  func() (string, error)
-	now      func() time.Time
+	prompter    interactive.Prompter
+	homeDir     func() (string, error)
+	now         func() time.Time
+	providers   func() []passwordmanager.Provider
+	provisioner managedAuthProvisioner
+}
+
+type pendingManagedAuth struct {
+	provider   passwordmanager.Provider
+	candidates []passwordmanager.Candidate
 }
 
 func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
@@ -71,6 +82,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		return err
 	}
 	humanOutput := in.Output != "json"
+	nonInteractive := in.SkipConfirm || !humanOutput
 	if humanOutput {
 		pterm.Info.Println("Looking for local Chrome profiles...")
 	}
@@ -110,12 +122,18 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 			return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
 		}
 	}
-	selected, err := c.chooseSites(recent, in.Sites, in.Count, in.SkipConfirm)
+	selected, err := c.chooseSites(recent, in.Sites, in.Count, nonInteractive)
 	if err != nil {
 		return err
 	}
 	if len(selected) == 0 {
 		return fmt.Errorf("select at least one website")
+	}
+	phaseStarted = time.Now()
+	pendingLogins, err := c.chooseManagedAuthLogins(ctx, selected, in.PasswordManager, nonInteractive, humanOutput)
+	timings["password_manager_discovery"] = time.Since(phaseStarted)
+	if err != nil {
+		return err
 	}
 
 	if humanOutput {
@@ -136,7 +154,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		printSelectedSites(selectedSites)
 	}
 
-	if !in.SkipConfirm {
+	if !nonInteractive {
 		ok, err := c.prompter.Confirm("import browser data", fmt.Sprintf("Import %d cookies into Kernel profile %q?", len(cookies), targetName))
 		if err != nil {
 			return err
@@ -204,8 +222,42 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		return fmt.Errorf("browser import completed without a profile")
 	}
 	profileID := status.Applied.Profiles[0].ProfileID
+	connectionIDs := make([]string, 0)
+	approvedLogins := make([]passwordmanager.Record, 0)
+	if pendingLogins.provider != nil && len(pendingLogins.candidates) > 0 {
+		phaseStarted = time.Now()
+		approvedLogins, err = pendingLogins.provider.Reveal(ctx, pendingLogins.candidates)
+		timings["password_manager_reveal"] = time.Since(phaseStarted)
+		if err != nil {
+			return fmt.Errorf("profile %s is ready, but approved password-manager items could not be read: %w", targetName, err)
+		}
+	}
+	if len(approvedLogins) > 0 {
+		if c.provisioner == nil {
+			return fmt.Errorf("managed auth importer is unavailable")
+		}
+		if humanOutput {
+			pterm.Info.Printf("Creating %d Managed Auth connections...\n", len(approvedLogins))
+		}
+		phaseStarted = time.Now()
+		connectionIDs, err = c.provisioner.Provision(ctx, targetName, approvedLogins)
+		timings["managed_auth"] = time.Since(phaseStarted)
+		if err != nil {
+			return fmt.Errorf("profile %s is ready, but Managed Auth setup stopped: %w", targetName, err)
+		}
+	}
+	installedSkills := 0
+	skillWarning := ""
+	if len(connectionIDs) > 0 {
+		phaseStarted = time.Now()
+		installedSkills, err = c.offerAgentSkills(home, in.InstallAgentSkills, nonInteractive, humanOutput)
+		timings["agent_skills"] = time.Since(phaseStarted)
+		if err != nil {
+			skillWarning = err.Error()
+		}
+	}
 	if in.Output == "json" {
-		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies), "duration_ms": time.Since(startedAt).Milliseconds(), "timings_ms": durationMilliseconds(timings)}, "", "  ")
+		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies), "managed_auth_connections": connectionIDs, "agent_skills_installed": installedSkills, "agent_skill_warning": skillWarning, "duration_ms": time.Since(startedAt).Milliseconds(), "timings_ms": durationMilliseconds(timings)}, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -214,9 +266,165 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	}
 	pterm.Success.Printf("%s is ready for agents\n", targetName)
 	pterm.Printf("Imported %d cookies from %d websites\n", len(cookies), len(selected))
+	if len(connectionIDs) > 0 {
+		pterm.Printf("Created %d Managed Auth connections with credentials and supported TOTP secrets\n", len(connectionIDs))
+	}
+	if skillWarning != "" {
+		pterm.Warning.Printf("Managed Auth is ready, but agent skill installation was skipped: %s\n", skillWarning)
+	}
 	pterm.Printf("Completed in %s (local read %s, upload and apply %s)\n", time.Since(startedAt).Round(time.Millisecond), (timings["history"] + timings["cookies"]).Round(time.Millisecond), timings["upload_and_apply"].Round(time.Millisecond))
+	if len(connectionIDs) > 0 {
+		pterm.Printf("Password manager %s, Managed Auth %s\n", (timings["password_manager_discovery"] + timings["password_manager_reveal"]).Round(time.Millisecond), timings["managed_auth"].Round(time.Millisecond))
+	}
 	pterm.Printf("Next: kernel browsers create --profile %s\n", targetName)
 	return nil
+}
+
+func (c ProfilesImportLocalCmd) offerAgentSkills(home string, installRequested, nonInteractive, humanOutput bool) (int, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return 0, err
+	}
+	targets := agentskills.Detect(workingDirectory, home)
+	if len(targets) == 0 {
+		return 0, nil
+	}
+	if !installRequested {
+		if nonInteractive {
+			return 0, nil
+		}
+		approved, err := c.prompter.Confirm("install agent skill", "Install the Kernel Managed Auth skill for your local agents?")
+		if err != nil || !approved {
+			return 0, err
+		}
+	}
+	labels := make([]string, 0, len(targets))
+	byLabel := make(map[string]agentskills.Target, len(targets))
+	for _, target := range targets {
+		label := fmt.Sprintf("%-10s %s", target.Agent, target.Path)
+		labels = append(labels, label)
+		byLabel[label] = target
+	}
+	selectedLabels := labels
+	if !nonInteractive {
+		selectedLabels, err = c.prompter.MultiSelect("agent skills", "pass --install-agent-skills", "Choose agents that should learn Managed Auth", labels, labels)
+		if err != nil {
+			return 0, err
+		}
+	}
+	selected := make([]agentskills.Target, 0, len(selectedLabels))
+	for _, label := range selectedLabels {
+		selected = append(selected, byLabel[label])
+	}
+	if err := agentskills.Install(selected); err != nil {
+		return 0, err
+	}
+	if humanOutput {
+		pterm.Success.Printf("Installed the Kernel Managed Auth skill for %d agent environments\n", len(selected))
+	}
+	return len(selected), nil
+}
+
+func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sites []string, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
+	if requested == "none" || (requested == "" && nonInteractive) {
+		return pendingManagedAuth{}, nil
+	}
+	if c.providers == nil {
+		c.providers = passwordmanager.Detect
+	}
+	providers := c.providers()
+	if len(providers) == 0 {
+		if requested != "" {
+			return pendingManagedAuth{}, fmt.Errorf("no supported password-manager CLI was found; install `bw` or `op`, then retry")
+		}
+		if humanOutput {
+			pterm.Info.Println("No Bitwarden or 1Password CLI found; continuing with cookies")
+		}
+		return pendingManagedAuth{}, nil
+	}
+	chosen := requested
+	if chosen == "" {
+		options := []string{"Skip passwords for now"}
+		for _, provider := range providers {
+			options = append(options, provider.Name())
+		}
+		selection, err := c.prompter.Select("password manager", "pass --password-manager", "Bring matching logins into Managed Auth?", options)
+		if err != nil {
+			return pendingManagedAuth{}, err
+		}
+		if selection == options[0] {
+			return pendingManagedAuth{}, nil
+		}
+		chosen = strings.ToLower(strings.ReplaceAll(selection, "Password", "password"))
+	}
+	var provider passwordmanager.Provider
+	for _, candidate := range providers {
+		id := strings.ToLower(strings.ReplaceAll(candidate.Name(), "Password", "password"))
+		if strings.EqualFold(chosen, id) || (chosen == "1password" && candidate.Name() == "1Password") || (chosen == "bitwarden" && candidate.Name() == "Bitwarden") {
+			provider = candidate
+			break
+		}
+	}
+	if provider == nil {
+		return pendingManagedAuth{}, fmt.Errorf("password manager %q is unavailable; use bitwarden, 1password, or none", requested)
+	}
+	if humanOutput {
+		pterm.Info.Printf("Authorize %s locally to find matching logins...\n", provider.Name())
+	}
+	candidates, err := provider.Candidates(ctx, sites)
+	if err != nil {
+		return pendingManagedAuth{}, err
+	}
+	if len(candidates) == 0 {
+		if humanOutput {
+			pterm.Info.Printf("No %s logins matched the selected websites\n", provider.Name())
+		}
+		return pendingManagedAuth{}, nil
+	}
+	labels := make([]string, 0, len(candidates))
+	byLabel := make(map[string]passwordmanager.Candidate, len(candidates))
+	defaultLabels := make([]string, 0, len(sites))
+	domainCounts := make(map[string]int, len(sites))
+	for _, candidate := range candidates {
+		domainCounts[candidate.Domain]++
+	}
+	for index, candidate := range candidates {
+		idSuffix := candidate.ID
+		if len(idSuffix) > 6 {
+			idSuffix = idSuffix[len(idSuffix)-6:]
+		}
+		label := fmt.Sprintf("%2d  %-28s %-28s %s · %s", index+1, candidate.Domain, candidate.Username, candidate.Name, idSuffix)
+		labels = append(labels, label)
+		byLabel[label] = candidate
+		if domainCounts[candidate.Domain] == 1 {
+			defaultLabels = append(defaultLabels, label)
+		}
+	}
+	if nonInteractive {
+		for domain, count := range domainCounts {
+			if count > 1 {
+				return pendingManagedAuth{}, fmt.Errorf("%s has %d matching logins; rerun interactively to choose one", domain, count)
+			}
+		}
+	}
+	chosenLabels := defaultLabels
+	if !nonInteractive {
+		chosenLabels, err = c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", "Choose logins to create in Managed Auth", labels, defaultLabels)
+		if err != nil {
+			return pendingManagedAuth{}, err
+		}
+	}
+	approved := make([]passwordmanager.Candidate, 0, len(chosenLabels))
+	selectedDomains := make(map[string]struct{}, len(chosenLabels))
+	for _, label := range chosenLabels {
+		candidate := byLabel[label]
+		if _, exists := selectedDomains[candidate.Domain]; exists {
+			return pendingManagedAuth{}, fmt.Errorf("select at most one login for %s", candidate.Domain)
+		}
+		selectedDomains[candidate.Domain] = struct{}{}
+		approved = append(approved, candidate)
+	}
+	return pendingManagedAuth{provider: provider, candidates: approved}, nil
 }
 
 func browserImportProgressError(importID, phase string, elapsed time.Duration, err error) error {
@@ -438,6 +646,8 @@ func init() {
 	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
 	profilesImportLocalCmd.Flags().Duration("wait-timeout", 30*time.Minute, "Maximum time to wait for the import to complete")
 	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
+	profilesImportLocalCmd.Flags().String("password-manager", "", "Import matching logins into Managed Auth: bitwarden, 1password, or none")
+	profilesImportLocalCmd.Flags().Bool("install-agent-skills", false, "Install the Kernel Managed Auth skill into detected agent directories")
 	addJSONOutputFlag(profilesImportLocalCmd)
 	addJSONOutputFlag(profilesImportStatusCmd)
 }
@@ -450,9 +660,14 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	days, _ := cmd.Flags().GetInt("days")
 	waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
+	passwordManager, _ := cmd.Flags().GetString("password-manager")
+	installAgentSkills, _ := cmd.Flags().GetBool("install-agent-skills")
 	output, _ := cmd.Flags().GetString("output")
 	project, _ := cmd.Flags().GetString("project")
 	project = resolveProjectSelection(project)
-	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter()}
-	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version, WaitTimeout: waitTimeout})
+	client := getKernelClient(cmd)
+	credentials := client.Credentials
+	connections := client.Auth.Connections
+	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter(), providers: passwordmanager.Detect, provisioner: kernelManagedAuthProvisioner{credentials: &credentials, connections: &connections}}
+	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version, WaitTimeout: waitTimeout, PasswordManager: passwordManager, InstallAgentSkills: installAgentSkills})
 }

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -136,20 +136,35 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 			return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
 		}
 	}
-	selected, err := c.chooseSites(recent, in.Sites, in.Count, nonInteractive)
+	explicitSites := in.Sites
+	if len(explicitSites) > 0 {
+		explicitSites, err = normalizeSites(explicitSites)
+		if err != nil {
+			return err
+		}
+	}
+	if len(explicitSites) == 0 {
+		if humanOutput {
+			pterm.Info.Printf("Counting cookies for %d recent websites...\n", len(recent))
+		}
+		phaseStarted = time.Now()
+		recent, err = localbrowser.CountCookiesForSites(ctx, profile, recent)
+		timings["cookie_counts"] = time.Since(phaseStarted)
+		if err != nil {
+			return err
+		}
+		recent = sitesWithCookies(recent)
+		if len(recent) == 0 {
+			return fmt.Errorf("the recent websites have no importable cookies")
+		}
+	}
+	selected, err := c.chooseSites(recent, explicitSites, in.Count, nonInteractive)
 	if err != nil {
 		return err
 	}
 	if len(selected) == 0 {
 		return fmt.Errorf("select at least one website")
 	}
-	phaseStarted = time.Now()
-	pendingLogins, err := c.chooseManagedAuthLogins(ctx, selected, in.PasswordManager, nonInteractive, humanOutput)
-	timings["password_manager_discovery"] = time.Since(phaseStarted)
-	if err != nil {
-		return err
-	}
-
 	if humanOutput {
 		pterm.Info.Printf("Reading cookies for %d selected websites...\n", len(selected))
 	}
@@ -162,21 +177,11 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if len(cookies) == 0 {
 		return fmt.Errorf("the selected websites have no importable cookies")
 	}
-	selectedSites := selectedSiteDetails(recent, selected)
-	selectedSites = localbrowser.CountCookiesBySite(cookies, selectedSites)
-	if humanOutput {
-		printSelectedSites(selectedSites)
-	}
-
-	if !nonInteractive {
-		ok, err := c.prompter.Confirm("import browser data", fmt.Sprintf("Import %d cookies into Kernel profile %q?", len(cookies), targetName))
-		if err != nil {
-			return err
-		}
-		if !ok {
-			pterm.Info.Println("Import cancelled")
-			return nil
-		}
+	phaseStarted = time.Now()
+	pendingLogins, err := c.chooseManagedAuthLogins(ctx, selected, in.PasswordManager, nonInteractive, humanOutput)
+	timings["password_manager_discovery"] = time.Since(phaseStarted)
+	if err != nil {
+		return err
 	}
 
 	version := in.Version
@@ -674,14 +679,14 @@ func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requeste
 	byLabel := make(map[string]string, len(recent))
 	defaultLabels := make([]string, 0, count)
 	for index, site := range recent {
-		label := fmt.Sprintf("%-32s %d visits", site.Domain, site.Visits)
+		label := cookieSiteLabel(site)
 		labels = append(labels, label)
 		byLabel[label] = site.Domain
 		if index < count {
 			defaultLabels = append(defaultLabels, label)
 		}
 	}
-	chosen, err := c.prompter.MultiSelect("websites", "pass --sites or --yes", "Choose websites to bring to Kernel", labels, defaultLabels)
+	chosen, err := c.prompter.MultiSelect("websites", "pass --sites or --yes", "Choose websites whose cookies should be imported", labels, defaultLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -690,6 +695,29 @@ func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requeste
 		result = append(result, byLabel[label])
 	}
 	return result, nil
+}
+
+func cookieSiteLabel(site localbrowser.Site) string {
+	label := fmt.Sprintf("%-28s %s visits · %s cookies", compactField(site.Domain, 28), boundedCount(site.Visits), boundedCount(site.CookieCount))
+	return ansi.Truncate(label, 64, "…")
+}
+
+func boundedCount(value int) string {
+	text := fmt.Sprintf("%d", value)
+	if len(text) <= 9 {
+		return text
+	}
+	return fmt.Sprintf("%.2e", float64(value))
+}
+
+func sitesWithCookies(sites []localbrowser.Site) []localbrowser.Site {
+	result := make([]localbrowser.Site, 0, len(sites))
+	for _, site := range sites {
+		if site.CookieCount > 0 {
+			result = append(result, site)
+		}
+	}
+	return result
 }
 
 func normalizeSites(values []string) ([]string, error) {
@@ -716,28 +744,6 @@ func normalizeSites(values []string) ([]string, error) {
 	}
 	sort.Strings(result)
 	return result, nil
-}
-
-func selectedSiteDetails(recent []localbrowser.Site, selected []string) []localbrowser.Site {
-	byDomain := make(map[string]localbrowser.Site, len(recent))
-	for _, site := range recent {
-		byDomain[site.Domain] = site
-	}
-	result := make([]localbrowser.Site, 0, len(selected))
-	for _, domain := range selected {
-		site := byDomain[domain]
-		site.Domain = domain
-		result = append(result, site)
-	}
-	return result
-}
-
-func printSelectedSites(sites []localbrowser.Site) {
-	rows := pterm.TableData{{"Website", "Recent visits", "Cookies"}}
-	for _, site := range sites {
-		rows = append(rows, []string{site.Domain, fmt.Sprintf("%d", site.Visits), fmt.Sprintf("%d", site.CookieCount)})
-	}
-	PrintTableNoPad(rows, true)
 }
 
 func defaultImportedProfileName(profile localbrowser.Profile) string {

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -368,8 +368,32 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 	if provider == nil {
 		return pendingManagedAuth{}, fmt.Errorf("password manager %q is unavailable; use bitwarden, 1password, or none", requested)
 	}
+	if authorizer, ok := provider.(passwordmanager.InteractiveAuthorizer); ok {
+		required, err := authorizer.AuthorizationRequired(ctx)
+		if err != nil {
+			return pendingManagedAuth{}, err
+		}
+		if required {
+			if nonInteractive {
+				return pendingManagedAuth{}, fmt.Errorf("Bitwarden is locked; unlock it with `export BW_SESSION=$(bw unlock --raw)`, then retry")
+			}
+			approved, err := c.prompter.Confirm("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?")
+			if err != nil {
+				return pendingManagedAuth{}, err
+			}
+			if !approved {
+				return pendingManagedAuth{}, nil
+			}
+			if err := authorizer.Authorize(ctx); err != nil {
+				return pendingManagedAuth{}, err
+			}
+			if humanOutput {
+				pterm.Success.Println("Bitwarden unlocked for this import")
+			}
+		}
+	}
 	if humanOutput {
-		pterm.Info.Printf("Authorize %s locally to find matching logins...\n", provider.Name())
+		pterm.Info.Printf("Find matching %s logins...\n", provider.Name())
 	}
 	candidates, err := provider.Candidates(ctx, sites)
 	if err != nil {

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	localbrowser "github.com/kernel/cli/internal/browserimport"
+	"github.com/kernel/cli/internal/passwordmanager"
 	"github.com/kernel/cli/pkg/interactive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +15,35 @@ func TestNormalizeSitesFlattensDeduplicatesAndSorts(t *testing.T) {
 	sites, err := normalizeSites([]string{" GitHub.com,example.com ", "github.com"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"example.com", "github.com"}, sites)
+}
+
+type fakePasswordManager struct{ candidates []passwordmanager.Candidate }
+
+func (fakePasswordManager) Name() string { return "Bitwarden" }
+func (f fakePasswordManager) Candidates(context.Context, []string) ([]passwordmanager.Candidate, error) {
+	return f.candidates, nil
+}
+func (f fakePasswordManager) Reveal(_ context.Context, candidates []passwordmanager.Candidate) ([]passwordmanager.Record, error) {
+	records := make([]passwordmanager.Record, 0, len(candidates))
+	for _, candidate := range candidates {
+		records = append(records, passwordmanager.Record{Provider: candidate.Provider, ID: candidate.ID, Domain: candidate.Domain, Username: candidate.Username, Name: candidate.Name})
+	}
+	return records, nil
+}
+
+func TestChooseManagedAuthLoginsRequiresChoiceForAmbiguousSite(t *testing.T) {
+	records := []passwordmanager.Candidate{
+		{ID: "one", Domain: "github.com", Username: "one", Name: "One"},
+		{ID: "two", Domain: "github.com", Username: "two", Name: "Two"},
+		{ID: "three", Domain: "example.com", Username: "three", Name: "Three"},
+	}
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: records}}
+	}}
+	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com", "example.com"}, "bitwarden", true, false)
+	require.Error(t, err)
+	assert.Empty(t, selected.candidates)
+	assert.Contains(t, err.Error(), "github.com has 2 matching logins")
 }
 
 func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -50,7 +50,7 @@ func TestCompactFieldPreventsLoginRowsFromWrapping(t *testing.T) {
 	assert.LessOrEqual(t, ansi.StringWidth(compactField("界界界界界", 6)), 6)
 	assert.Equal(t, "safe fake", compactField("\x1b[31msafe\x1b[0m\n\x1b]8;;https://example.com\x07fake\x1b]8;;\x07", 20))
 
-	label := loginCandidateLabel(1, passwordmanager.Candidate{
+	label := loginCandidateLabel(1, "Bitwarden", passwordmanager.Candidate{
 		Domain:   "accounts.google.com",
 		Username: "same-account@example.com",
 		Name:     "personal google account",
@@ -58,7 +58,7 @@ func TestCompactFieldPreventsLoginRowsFromWrapping(t *testing.T) {
 	assert.LessOrEqual(t, ansi.StringWidth(label), 72)
 	assert.Contains(t, label, "personal google")
 
-	withoutUsername := loginCandidateLabel(2, passwordmanager.Candidate{
+	withoutUsername := loginCandidateLabel(2, "1Password", passwordmanager.Candidate{
 		Domain: "example.com",
 		Name:   "personal account",
 	}, "def456")
@@ -66,7 +66,7 @@ func TestCompactFieldPreventsLoginRowsFromWrapping(t *testing.T) {
 	assert.Contains(t, withoutUsername, "personal account")
 
 	for _, index := range []int{999, 9999} {
-		label := loginCandidateLabel(index, passwordmanager.Candidate{
+		label := loginCandidateLabel(index, "Bitwarden", passwordmanager.Candidate{
 			Domain:   "accounts.google.com",
 			Username: "same-account@example.com",
 			Name:     "personal google account",
@@ -81,11 +81,20 @@ func TestProjectOptionLabelsAreUniqueForDuplicateNames(t *testing.T) {
 	assert.NotEqual(t, first, second)
 }
 
-type fakePasswordManager struct{ candidates []passwordmanager.Candidate }
+type fakePasswordManager struct {
+	name       string
+	candidates []passwordmanager.Candidate
+	err        error
+}
 
-func (fakePasswordManager) Name() string { return "Bitwarden" }
+func (f fakePasswordManager) Name() string {
+	if f.name != "" {
+		return f.name
+	}
+	return "Bitwarden"
+}
 func (f fakePasswordManager) Candidates(context.Context, []string) ([]passwordmanager.Candidate, error) {
-	return f.candidates, nil
+	return f.candidates, f.err
 }
 func (f fakePasswordManager) Reveal(_ context.Context, candidates []passwordmanager.Candidate) ([]passwordmanager.Record, error) {
 	records := make([]passwordmanager.Record, 0, len(candidates))
@@ -106,8 +115,59 @@ func TestChooseManagedAuthLoginsRequiresChoiceForAmbiguousSite(t *testing.T) {
 	}}
 	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com", "example.com"}, "bitwarden", true, false)
 	require.Error(t, err)
-	assert.Empty(t, selected.candidates)
+	assert.Empty(t, selected.providers)
 	assert.Contains(t, err.Error(), "github.com has 2 matching logins")
+}
+
+func TestChooseManagedAuthLoginsCombinesSelectedProviders(t *testing.T) {
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{
+			fakePasswordManager{name: "Bitwarden", candidates: []passwordmanager.Candidate{{ID: "bw", Domain: "github.com", Name: "GitHub personal"}}},
+			fakePasswordManager{name: "1Password", candidates: []passwordmanager.Candidate{{ID: "op", Domain: "example.com", Name: "Example work"}}},
+		}
+	}}
+
+	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com", "example.com"}, "bitwarden,1password", true, false)
+	require.NoError(t, err)
+	require.Len(t, selected.providers, 2)
+	assert.Equal(t, "Bitwarden", selected.providers[0].provider.Name())
+	assert.Equal(t, "github.com", selected.providers[0].candidates[0].Domain)
+	assert.Equal(t, "1Password", selected.providers[1].provider.Name())
+	assert.Equal(t, "example.com", selected.providers[1].candidates[0].Domain)
+}
+
+func TestChooseManagedAuthLoginsDeduplicatesRequestedProviders(t *testing.T) {
+	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{
+			fakePasswordManager{name: "Bitwarden", candidates: []passwordmanager.Candidate{{ID: "bw", Domain: "github.com", Name: "GitHub personal"}}},
+		}
+	}}
+
+	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com"}, "bitwarden,bitwarden", true, false)
+	require.NoError(t, err)
+	require.Len(t, selected.providers, 1)
+	require.Len(t, selected.providers[0].candidates, 1)
+}
+
+func TestChooseManagedAuthLoginsSkipsBrokenInteractiveProvider(t *testing.T) {
+	broken, err := discoverProviderCandidates(t.Context(), fakePasswordManager{name: "Bitwarden", err: assert.AnError}, []string{"example.com"}, false, false)
+	require.NoError(t, err)
+	assert.Empty(t, broken)
+
+	healthy, err := discoverProviderCandidates(t.Context(), fakePasswordManager{name: "1Password", candidates: []passwordmanager.Candidate{{ID: "op", Domain: "example.com"}}}, []string{"example.com"}, false, false)
+	require.NoError(t, err)
+	require.Len(t, healthy, 1)
+}
+
+func TestDuplicateSelectedDomainAcrossProviders(t *testing.T) {
+	provider := fakePasswordManager{name: "Bitwarden"}
+	candidates := map[string]sourcedPasswordManagerCandidate{
+		"bitwarden": {provider: provider, candidate: passwordmanager.Candidate{Domain: "google.com"}},
+		"1password": {provider: fakePasswordManager{name: "1Password"}, candidate: passwordmanager.Candidate{Domain: "google.com"}},
+	}
+
+	assert.Equal(t, "google.com", duplicateSelectedDomain([]string{"bitwarden", "1password"}, candidates))
+	assert.Empty(t, duplicateSelectedDomain([]string{"bitwarden"}, candidates))
 }
 
 func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -188,6 +188,25 @@ func TestChooseSitesUsesTopFiveWithYes(t *testing.T) {
 	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com"}, selected)
 }
 
+func TestCookieSiteLabelShowsRankingAndCookieCount(t *testing.T) {
+	label := cookieSiteLabel(localbrowser.Site{Domain: "google.com", Visits: 2347, CookieCount: 64})
+	assert.Contains(t, label, "google.com")
+	assert.Contains(t, label, "2347 visits")
+	assert.Contains(t, label, "64 cookies")
+	assert.LessOrEqual(t, ansi.StringWidth(label), 64)
+	assert.LessOrEqual(t, ansi.StringWidth(cookieSiteLabel(localbrowser.Site{Domain: "界界界界界界界界界界界界界界界界", Visits: int(^uint(0) >> 1), CookieCount: int(^uint(0) >> 1)})), 64)
+	assert.Equal(t, "1.00e+09", boundedCount(1_000_000_000))
+}
+
+func TestSitesWithCookiesOmitsEmptySitesAndPreservesRanking(t *testing.T) {
+	sites := sitesWithCookies([]localbrowser.Site{
+		{Domain: "first.com", Visits: 10, CookieCount: 2},
+		{Domain: "empty.com", Visits: 9},
+		{Domain: "second.com", Visits: 8, CookieCount: 1},
+	})
+	assert.Equal(t, []string{"first.com", "second.com"}, []string{sites[0].Domain, sites[1].Domain})
+}
+
 func TestChooseSitesFailsFastWithoutTTYOrFlags(t *testing.T) {
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
 	_, err := command.chooseSites([]localbrowser.Site{{Domain: "example.com"}}, nil, 5, false)

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -4,17 +4,81 @@ import (
 	"context"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	localbrowser "github.com/kernel/cli/internal/browserimport"
 	"github.com/kernel/cli/internal/passwordmanager"
 	"github.com/kernel/cli/pkg/interactive"
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/pagination"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeProjectListService struct{ projects []kernel.Project }
+
+func (f fakeProjectListService) List(context.Context, kernel.ProjectListParams, ...option.RequestOption) (*pagination.OffsetPagination[kernel.Project], error) {
+	return &pagination.OffsetPagination[kernel.Project]{Items: f.projects}, nil
+}
 
 func TestNormalizeSitesFlattensDeduplicatesAndSorts(t *testing.T) {
 	sites, err := normalizeSites([]string{" GitHub.com,example.com ", "github.com"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"example.com", "github.com"}, sites)
+}
+
+func TestChooseImportProjectUsesOnlyActiveProject(t *testing.T) {
+	project, err := chooseImportProject(t.Context(), fakeProjectListService{projects: []kernel.Project{
+		{ID: "archived", Name: "Old", Status: kernel.ProjectStatusArchived},
+		{ID: "active", Name: "Default", Status: kernel.ProjectStatusActive},
+	}}, interactive.NewPrompterWithTerminal(false), "", false)
+	require.NoError(t, err)
+	assert.Equal(t, "active", project)
+}
+
+func TestChooseImportProjectRequiresFlagForMultipleNonInteractiveProjects(t *testing.T) {
+	_, err := chooseImportProject(t.Context(), fakeProjectListService{projects: []kernel.Project{
+		{ID: "one", Name: "One", Status: kernel.ProjectStatusActive},
+		{ID: "two", Name: "Two", Status: kernel.ProjectStatusActive},
+	}}, interactive.NewPrompterWithTerminal(false), "", true)
+	require.ErrorContains(t, err, "pass --project")
+}
+
+func TestCompactFieldPreventsLoginRowsFromWrapping(t *testing.T) {
+	assert.Equal(t, "short", compactField("short", 8))
+	assert.Equal(t, "very-lo…", compactField("very-long-value", 8))
+	assert.LessOrEqual(t, ansi.StringWidth(compactField("界界界界界", 6)), 6)
+	assert.Equal(t, "safe fake", compactField("\x1b[31msafe\x1b[0m\n\x1b]8;;https://example.com\x07fake\x1b]8;;\x07", 20))
+
+	label := loginCandidateLabel(1, passwordmanager.Candidate{
+		Domain:   "accounts.google.com",
+		Username: "same-account@example.com",
+		Name:     "personal google account",
+	}, "abc123")
+	assert.LessOrEqual(t, ansi.StringWidth(label), 72)
+	assert.Contains(t, label, "personal google")
+
+	withoutUsername := loginCandidateLabel(2, passwordmanager.Candidate{
+		Domain: "example.com",
+		Name:   "personal account",
+	}, "def456")
+	assert.Contains(t, withoutUsername, "no username")
+	assert.Contains(t, withoutUsername, "personal account")
+
+	for _, index := range []int{999, 9999} {
+		label := loginCandidateLabel(index, passwordmanager.Candidate{
+			Domain:   "accounts.google.com",
+			Username: "same-account@example.com",
+			Name:     "personal google account",
+		}, "abc123")
+		assert.LessOrEqual(t, ansi.StringWidth(label), 72)
+	}
+}
+
+func TestProjectOptionLabelsAreUniqueForDuplicateNames(t *testing.T) {
+	first := projectOptionLabel(0, kernel.Project{Name: "Duplicate"})
+	second := projectOptionLabel(1, kernel.Project{Name: "Duplicate"})
+	assert.NotEqual(t, first, second)
 }
 
 type fakePasswordManager struct{ candidates []passwordmanager.Candidate }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kernel/cli
 go 1.25.0
 
 require (
+	atomicgo.dev/keyboard v0.2.9
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/boyter/gocodewalker v1.4.0
 	github.com/charmbracelet/fang v0.2.0
@@ -29,7 +30,6 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	atomicgo.dev/cursor v0.2.0 // indirect
-	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/boyter/gocodewalker v1.4.0
 	github.com/charmbracelet/fang v0.2.0
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
+	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
 	github.com/kernel/kernel-go-sdk v0.87.0
@@ -31,7 +32,6 @@ require (
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/boyter/gocodewalker v1.4.0
 	github.com/charmbracelet/fang v0.2.0
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
+	github.com/charmbracelet/x/ansi v0.8.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
 	github.com/kernel/kernel-go-sdk v0.92.0
@@ -31,7 +32,6 @@ require (
 	atomicgo.dev/keyboard v0.2.9 // indirect
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250603201427-c31516f43444 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/internal/agentskills/install.go
+++ b/internal/agentskills/install.go
@@ -1,0 +1,119 @@
+package agentskills
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Target is an installed agent's skill directory.
+type Target struct {
+	Agent string
+	Path  string
+}
+
+var relativeSkillDirectories = []Target{
+	{Agent: "Agent", Path: ".agent/skills"},
+	{Agent: "Agents", Path: ".agents/skills"},
+	{Agent: "Claude", Path: ".claude/skills"},
+	{Agent: "Codex", Path: ".codex/skills"},
+	{Agent: "Pi", Path: ".pi/skills"},
+	{Agent: "OMP", Path: ".omp/skills"},
+	{Agent: "Factory", Path: ".factory/skills"},
+}
+
+// Detect returns skill roots whose parent agent directory already exists.
+func Detect(workingDirectory, home string) []Target {
+	seen := make(map[string]struct{})
+	result := make([]Target, 0)
+	for _, base := range []string{workingDirectory, home} {
+		for _, candidate := range relativeSkillDirectories {
+			path := filepath.Join(base, candidate.Path)
+			info, err := os.Lstat(filepath.Dir(path))
+			if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				continue
+			}
+			if _, exists := seen[path]; exists {
+				continue
+			}
+			seen[path] = struct{}{}
+			result = append(result, Target{Agent: candidate.Agent, Path: path})
+		}
+	}
+	return result
+}
+
+// Install writes the Kernel Managed Auth skill into the selected agent roots.
+func Install(targets []Target) error {
+	for _, target := range targets {
+		if err := preflight(target); err != nil {
+			return err
+		}
+	}
+	for _, target := range targets {
+		directory := filepath.Join(target.Path, "kernel-managed-auth")
+		if err := os.MkdirAll(directory, 0o755); err != nil {
+			return fmt.Errorf("create %s skill directory: %w", target.Agent, err)
+		}
+		destination := filepath.Join(directory, "SKILL.md")
+		if data, err := os.ReadFile(destination); err == nil && bytes.Equal(data, []byte(skill)) {
+			continue
+		}
+		temporary, err := os.CreateTemp(directory, ".SKILL.md-*")
+		if err != nil {
+			return fmt.Errorf("prepare %s skill: %w", target.Agent, err)
+		}
+		temporaryName := temporary.Name()
+		if _, err := temporary.WriteString(skill); err != nil {
+			temporary.Close()
+			os.Remove(temporaryName)
+			return fmt.Errorf("write %s skill: %w", target.Agent, err)
+		}
+		if err := temporary.Close(); err != nil {
+			os.Remove(temporaryName)
+			return err
+		}
+		if err := os.Rename(temporaryName, destination); err != nil {
+			os.Remove(temporaryName)
+			return fmt.Errorf("install %s skill: %w", target.Agent, err)
+		}
+	}
+	return nil
+}
+
+func preflight(target Target) error {
+	for _, path := range []string{target.Path, filepath.Join(target.Path, "kernel-managed-auth"), filepath.Join(target.Path, "kernel-managed-auth", "SKILL.md")} {
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing symlinked skill path %s", path)
+		}
+	}
+	destination := filepath.Join(target.Path, "kernel-managed-auth", "SKILL.md")
+	if data, err := os.ReadFile(destination); err == nil && !bytes.Equal(data, []byte(skill)) {
+		return fmt.Errorf("refusing to overwrite customized skill %s", destination)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+const skill = `---
+name: kernel-managed-auth
+description: Use Kernel Managed Auth connections when a browser needs to sign in or reauthenticate.
+---
+
+# Kernel Managed Auth
+
+1. List matching connections with ` + "`kernel auth connections list --domain <domain>`" + `.
+2. Start authentication with ` + "`kernel auth connections login <connection-id>`" + `.
+3. Follow progress with ` + "`kernel auth connections follow <connection-id>`" + `.
+4. If human input is requested, show the prompt; never request or print the stored password or TOTP secret.
+5. Start subsequent browsers with the Managed Auth connection's saved profile.
+`

--- a/internal/agentskills/install_test.go
+++ b/internal/agentskills/install_test.go
@@ -1,0 +1,48 @@
+package agentskills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectAndInstallOnlyExistingAgentDirectories(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".codex"), 0o755))
+	targets := Detect(root, t.TempDir())
+	require.Len(t, targets, 1)
+	assert.Equal(t, "Codex", targets[0].Agent)
+	require.NoError(t, Install(targets))
+	data, err := os.ReadFile(filepath.Join(root, ".codex", "skills", "kernel-managed-auth", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "kernel auth connections login")
+}
+
+func TestInstallRefusesCustomizedSkill(t *testing.T) {
+	root := t.TempDir()
+	target := Target{Agent: "Codex", Path: filepath.Join(root, ".codex", "skills")}
+	directory := filepath.Join(target.Path, "kernel-managed-auth")
+	require.NoError(t, os.MkdirAll(directory, 0o755))
+	destination := filepath.Join(directory, "SKILL.md")
+	require.NoError(t, os.WriteFile(destination, []byte("my custom skill"), 0o600))
+
+	err := Install([]Target{target})
+	require.ErrorContains(t, err, "refusing to overwrite customized skill")
+	data, readErr := os.ReadFile(destination)
+	require.NoError(t, readErr)
+	assert.Equal(t, "my custom skill", string(data))
+}
+
+func TestInstallRefusesSymlinkedSkillRoot(t *testing.T) {
+	root := t.TempDir()
+	realDirectory := filepath.Join(root, "real")
+	require.NoError(t, os.Mkdir(realDirectory, 0o755))
+	symlink := filepath.Join(root, "skills")
+	require.NoError(t, os.Symlink(realDirectory, symlink))
+
+	err := Install([]Target{{Agent: "Codex", Path: symlink}})
+	require.ErrorContains(t, err, "refusing symlinked skill path")
+}

--- a/internal/browserimport/chromium.go
+++ b/internal/browserimport/chromium.go
@@ -178,35 +178,11 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 		}
 	}
 	selectedSites = canonicalSites
-	path := filepath.Join(profile.Path, "Network/Cookies")
-	if _, err := os.Stat(path); err != nil {
-		path = filepath.Join(profile.Path, "Cookies")
-	}
-	snapshot, cleanup, err := sqliteSnapshot(ctx, path)
+	snapshot, whereClause, cleanup, err := cookieDatabaseSnapshot(ctx, profile)
 	if err != nil {
-		return nil, fmt.Errorf("snapshot cookie database: %w", err)
+		return nil, err
 	}
 	defer cleanup()
-	columnsData, err := sqliteJSON(ctx, snapshot, `SELECT name FROM pragma_table_info('cookies')`)
-	if err != nil {
-		return nil, fmt.Errorf("inspect cookie database: %w", err)
-	}
-	var columns []struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(columnsData, &columns); err != nil {
-		return nil, fmt.Errorf("decode cookie schema: %w", err)
-	}
-	partitionPredicates := []string{"(expires_utc = 0 OR expires_utc > " + fmt.Sprintf("%d", time.Now().UnixMicro()+11_644_473_600_000_000) + ")"}
-	for _, column := range columns {
-		switch column.Name {
-		case "top_frame_site_key":
-			partitionPredicates = append(partitionPredicates, "top_frame_site_key = ''")
-		case "is_partitioned":
-			partitionPredicates = append(partitionPredicates, "is_partitioned = 0")
-		}
-	}
-	whereClause := " WHERE " + strings.Join(partitionPredicates, " AND ")
 	siteClause := selectedCookieClause(selectedSites, true)
 	query := `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + whereClause + siteClause + ` ORDER BY host_key, name`
 	data, err := sqliteJSON(ctx, snapshot, query)
@@ -263,16 +239,71 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 	return cookies, nil
 }
 
-func CountCookiesBySite(cookies []Cookie, sites []Site) []Site {
+// CountCookiesForSites counts importable cookies without reading or decrypting their values.
+func CountCookiesForSites(ctx context.Context, profile Profile, sites []Site) ([]Site, error) {
+	selected := make([]string, 0, len(sites))
+	for _, site := range sites {
+		selected = append(selected, site.Domain)
+	}
+	snapshot, whereClause, cleanup, err := cookieDatabaseSnapshot(ctx, profile)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	data, err := sqliteJSON(ctx, snapshot, `SELECT host_key FROM cookies`+whereClause+selectedCookieClause(selected, true))
+	if err != nil {
+		return nil, fmt.Errorf("count browser cookies: %w", err)
+	}
+	var rows []struct {
+		Domain string `json:"host_key"`
+	}
+	if len(bytes.TrimSpace(data)) != 0 {
+		if err := json.Unmarshal(data, &rows); err != nil {
+			return nil, fmt.Errorf("decode browser cookie counts: %w", err)
+		}
+	}
 	result := append([]Site(nil), sites...)
 	for i := range result {
-		for _, cookie := range cookies {
-			if domainMatchesSite(cookie.Domain, result[i].Domain) {
+		for _, row := range rows {
+			if domainMatchesSite(row.Domain, result[i].Domain) {
 				result[i].CookieCount++
 			}
 		}
 	}
-	return result
+	return result, nil
+}
+
+func cookieDatabaseSnapshot(ctx context.Context, profile Profile) (string, string, func(), error) {
+	path := filepath.Join(profile.Path, "Network/Cookies")
+	if _, err := os.Stat(path); err != nil {
+		path = filepath.Join(profile.Path, "Cookies")
+	}
+	snapshot, cleanup, err := sqliteSnapshot(ctx, path)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("snapshot cookie database: %w", err)
+	}
+	columnsData, err := sqliteJSON(ctx, snapshot, `SELECT name FROM pragma_table_info('cookies')`)
+	if err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("inspect cookie database: %w", err)
+	}
+	var columns []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(columnsData, &columns); err != nil {
+		cleanup()
+		return "", "", nil, fmt.Errorf("decode cookie schema: %w", err)
+	}
+	predicates := []string{"(expires_utc = 0 OR expires_utc > " + fmt.Sprintf("%d", time.Now().UnixMicro()+11_644_473_600_000_000) + ")"}
+	for _, column := range columns {
+		switch column.Name {
+		case "top_frame_site_key":
+			predicates = append(predicates, "top_frame_site_key = ''")
+		case "is_partitioned":
+			predicates = append(predicates, "is_partitioned = 0")
+		}
+	}
+	return snapshot, " WHERE " + strings.Join(predicates, " AND "), cleanup, nil
 }
 
 func sqliteJSON(ctx context.Context, databasePath, query string) ([]byte, error) {

--- a/internal/browserimport/chromium_test.go
+++ b/internal/browserimport/chromium_test.go
@@ -213,6 +213,24 @@ func TestSelectedCookieClauseEscapesInput(t *testing.T) {
 	assert.NotContains(t, clause, "example.com' OR 1=1 --'")
 }
 
+func TestCountCookiesForSitesDoesNotDecryptValues(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "Network", "Cookies")
+	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
+	runSQLite(t, database, `
+CREATE TABLE cookies (
+  host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+  expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER
+);
+INSERT INTO cookies VALUES ('.google.com', '/', 'encrypted', '', X'DEADBEEF', 0, 1, 1, 1);
+`)
+
+	sites, err := CountCookiesForSites(t.Context(), profile, []Site{{Domain: "google.com"}, {Domain: "github.com"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, sites[0].CookieCount)
+	assert.Zero(t, sites[1].CookieCount)
+}
+
 func writeBrowserFixture(t *testing.T, home, rootSuffix, directory, name string) {
 	t.Helper()
 	root := filepath.Join(home, "Library/Application Support", rootSuffix)

--- a/internal/browserimport/client.go
+++ b/internal/browserimport/client.go
@@ -3,6 +3,8 @@ package browserimport
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -53,9 +55,33 @@ func NewClient(baseURL, token, projectID string) (*Client, error) {
 }
 
 func (c *Client) Create(ctx context.Context) (CreateResponse, error) {
-	var result CreateResponse
-	err := c.doJSON(ctx, http.MethodPost, "/browser-imports", c.token, nil, &result)
-	return result, err
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return CreateResponse{}, fmt.Errorf("create browser import idempotency key: %w", err)
+	}
+	idempotencyKey := hex.EncodeToString(keyBytes)
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/browser-imports", nil)
+		if err != nil {
+			return CreateResponse{}, err
+		}
+		c.setHeaders(request, c.token)
+		request.Header.Set("Idempotency-Key", idempotencyKey)
+		response, err := c.http.Do(request)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		var result CreateResponse
+		err = decodeResponse(response, &result)
+		response.Body.Close()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+	}
+	return CreateResponse{}, lastErr
 }
 
 func (c *Client) SubmitInventory(ctx context.Context, id, helperToken string, inventory Inventory) (Status, error) {

--- a/internal/browserimport/client_test.go
+++ b/internal/browserimport/client_test.go
@@ -63,6 +63,33 @@ func TestClientRunsBrowserImportLifecycleWithScopedTokens(t *testing.T) {
 	assert.Equal(t, "completed", status.Phase)
 }
 
+func TestCreateRetriesWithSameIdempotencyKey(t *testing.T) {
+	var calls atomic.Int32
+	var firstKey string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		key := request.Header.Get("Idempotency-Key")
+		require.NotEmpty(t, key)
+		if calls.Add(1) == 1 {
+			firstKey = key
+			hijacker := response.(http.Hijacker)
+			connection, _, err := hijacker.Hijack()
+			require.NoError(t, err)
+			connection.Close()
+			return
+		}
+		assert.Equal(t, firstKey, key)
+		response.WriteHeader(http.StatusCreated)
+		fmt.Fprint(response, `{"id":"imp_1","helper_token":"helper","helper_token_expires_at":"2030-01-01T00:00:00Z"}`)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "token", "")
+	require.NoError(t, err)
+	created, err := client.Create(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "imp_1", created.ID)
+	assert.EqualValues(t, 2, calls.Load())
+}
+
 func TestClientRejectsUntrustedPlaintextAPI(t *testing.T) {
 	_, err := NewClient("http://api.example.com", "token", "")
 	assert.EqualError(t, err, "Kernel API URL must use HTTPS or local development")

--- a/internal/passwordmanager/bitwarden.go
+++ b/internal/passwordmanager/bitwarden.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
-type bitwardenProvider struct{ path string }
+type bitwardenProvider struct {
+	path    string
+	session string
+}
 
 func (*bitwardenProvider) Name() string { return "Bitwarden" }
 
@@ -140,19 +144,72 @@ func (p *bitwardenProvider) Reveal(ctx context.Context, selected []Candidate) ([
 
 func (p *bitwardenProvider) authorizedEnvironment(ctx context.Context) (map[string]string, error) {
 	environment := map[string]string(nil)
-	if session := os.Getenv("BW_SESSION"); session != "" {
+	if p.session != "" {
+		environment = map[string]string{"BW_SESSION": p.session}
+	} else if session := os.Getenv("BW_SESSION"); session != "" {
 		environment = map[string]string{"BW_SESSION": session}
 	}
-	output, err := command(ctx, p.path, environment, "status")
+	status, err := p.status(ctx, environment)
 	if err != nil {
 		return nil, err
 	}
-	var status bitwardenStatus
-	if err := json.Unmarshal(output, &status); err != nil {
-		return nil, fmt.Errorf("decode Bitwarden status: %w", err)
-	}
 	if status.Status != "unlocked" {
-		return nil, fmt.Errorf("unlock Bitwarden for this terminal with `export BW_SESSION=$(bw unlock --raw)`, then retry")
+		return nil, fmt.Errorf("Bitwarden is locked")
 	}
 	return environment, nil
+}
+
+// AuthorizationRequired reports whether Bitwarden needs a local unlock.
+func (p *bitwardenProvider) AuthorizationRequired(ctx context.Context) (bool, error) {
+	environment := map[string]string(nil)
+	if p.session != "" {
+		environment = map[string]string{"BW_SESSION": p.session}
+	} else if session := os.Getenv("BW_SESSION"); session != "" {
+		environment = map[string]string{"BW_SESSION": session}
+	}
+	status, err := p.status(ctx, environment)
+	if err != nil {
+		return false, err
+	}
+	switch status.Status {
+	case "unlocked":
+		return false, nil
+	case "locked":
+		return true, nil
+	case "unauthenticated":
+		return false, fmt.Errorf("sign in to Bitwarden with `bw login`, then retry")
+	default:
+		return false, fmt.Errorf("unsupported Bitwarden status %q", status.Status)
+	}
+}
+
+// Authorize asks Bitwarden to unlock through its own terminal prompt and keeps
+// the resulting session key only in this process.
+func (p *bitwardenProvider) Authorize(ctx context.Context) error {
+	output, err := command(ctx, p.path, map[string]string{"BW_SESSION": ""}, "unlock", "--raw")
+	if err != nil {
+		return fmt.Errorf("unlock Bitwarden: %w", err)
+	}
+	session := strings.TrimSpace(string(output))
+	if session == "" || strings.ContainsAny(session, "\r\n\t ") {
+		return fmt.Errorf("Bitwarden returned an invalid session key")
+	}
+	p.session = session
+	if _, err := p.authorizedEnvironment(ctx); err != nil {
+		p.session = ""
+		return fmt.Errorf("verify Bitwarden unlock: %w", err)
+	}
+	return nil
+}
+
+func (p *bitwardenProvider) status(ctx context.Context, environment map[string]string) (bitwardenStatus, error) {
+	output, err := command(ctx, p.path, environment, "status")
+	if err != nil {
+		return bitwardenStatus{}, err
+	}
+	var status bitwardenStatus
+	if err := json.Unmarshal(output, &status); err != nil {
+		return bitwardenStatus{}, fmt.Errorf("decode Bitwarden status: %w", err)
+	}
+	return status, nil
 }

--- a/internal/passwordmanager/bitwarden.go
+++ b/internal/passwordmanager/bitwarden.go
@@ -1,0 +1,158 @@
+package passwordmanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type bitwardenProvider struct{ path string }
+
+func (*bitwardenProvider) Name() string { return "Bitwarden" }
+
+type bitwardenStatus struct {
+	Status string `json:"status"`
+}
+
+type bitwardenItem struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	OrganizationID string `json:"organizationId"`
+	Login          *struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		TOTP     string `json:"totp"`
+	} `json:"login"`
+}
+
+type bitwardenCandidateItem struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	OrganizationID string `json:"organizationId"`
+	Login          *struct {
+		Username string `json:"username"`
+	} `json:"login"`
+}
+
+func (p *bitwardenProvider) Candidates(ctx context.Context, sites []string) ([]Candidate, error) {
+	environment, err := p.authorizedEnvironment(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	candidates := make([]Candidate, 0)
+	for _, site := range sites {
+		items, err := p.candidateItems(ctx, environment, site)
+		if err != nil {
+			return nil, fmt.Errorf("find Bitwarden logins for %s: %w", site, err)
+		}
+		for _, item := range items {
+			if item.Login == nil || item.OrganizationID != "" {
+				continue
+			}
+			key := item.ID + "\x00" + site
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			candidates = append(candidates, Candidate{Provider: "bitwarden", ID: item.ID, Name: item.Name, Domain: site, Username: item.Login.Username})
+		}
+	}
+	return candidates, nil
+}
+
+func (p *bitwardenProvider) candidateItems(ctx context.Context, environment map[string]string, site string) ([]bitwardenCandidateItem, error) {
+	cmd := exec.CommandContext(ctx, p.path, "list", "items", "--url", site)
+	cmd.Env = os.Environ()
+	for key, value := range environment {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	cmd.Stderr = os.Stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(stdout)
+	token, err := decoder.Token()
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("Bitwarden item list is not an array")
+	}
+	items := make([]bitwardenCandidateItem, 0)
+	for decoder.More() {
+		var item bitwardenCandidateItem
+		if err := decoder.Decode(&item); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return nil, err
+		}
+		items = append(items, item)
+		if len(items) > 1000 {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return nil, fmt.Errorf("more than 1000 Bitwarden items matched %s", site)
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (p *bitwardenProvider) Reveal(ctx context.Context, selected []Candidate) ([]Record, error) {
+	environment, err := p.authorizedEnvironment(ctx)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]Record, 0, len(selected))
+	for _, candidate := range selected {
+		output, err := command(ctx, p.path, environment, "get", "item", candidate.ID)
+		if err != nil {
+			return nil, fmt.Errorf("read approved Bitwarden login %q: %w", candidate.Name, err)
+		}
+		var item bitwardenItem
+		if err := json.Unmarshal(output, &item); err != nil {
+			return nil, fmt.Errorf("decode approved Bitwarden login: %w", err)
+		}
+		if item.Login == nil || item.OrganizationID != "" {
+			continue
+		}
+		records = append(records, Record{Provider: "bitwarden", ID: item.ID, Name: item.Name, Domain: candidate.Domain, Username: item.Login.Username, Password: item.Login.Password, TOTPSecret: normalizeTOTP(item.Login.TOTP)})
+	}
+	return deduplicate(records), nil
+}
+
+func (p *bitwardenProvider) authorizedEnvironment(ctx context.Context) (map[string]string, error) {
+	environment := map[string]string(nil)
+	if session := os.Getenv("BW_SESSION"); session != "" {
+		environment = map[string]string{"BW_SESSION": session}
+	}
+	output, err := command(ctx, p.path, environment, "status")
+	if err != nil {
+		return nil, err
+	}
+	var status bitwardenStatus
+	if err := json.Unmarshal(output, &status); err != nil {
+		return nil, fmt.Errorf("decode Bitwarden status: %w", err)
+	}
+	if status.Status != "unlocked" {
+		return nil, fmt.Errorf("unlock Bitwarden for this terminal with `export BW_SESSION=$(bw unlock --raw)`, then retry")
+	}
+	return environment, nil
+}

--- a/internal/passwordmanager/onepassword.go
+++ b/internal/passwordmanager/onepassword.go
@@ -1,0 +1,265 @@
+package passwordmanager
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type onePasswordProvider struct{ path string }
+
+func (*onePasswordProvider) Name() string { return "1Password" }
+
+type onePasswordSummary struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	URLs  []struct {
+		Href string `json:"href"`
+	} `json:"urls"`
+	Vault struct {
+		ID string `json:"id"`
+	} `json:"vault"`
+}
+
+type onePasswordVault struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type onePasswordItem struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Vault struct {
+		ID string `json:"id"`
+	} `json:"vault"`
+	URLs []struct {
+		Href string `json:"href"`
+	} `json:"urls"`
+	Fields []struct {
+		ID, Label, Type, Purpose string
+		Value                    any `json:"value"`
+	} `json:"fields"`
+}
+
+func (p *onePasswordProvider) Candidates(ctx context.Context, sites []string) ([]Candidate, error) {
+	summaries, err := p.personalSummaries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]Candidate, 0)
+	needsDetails := make([]onePasswordSummary, 0)
+	for _, summary := range summaries {
+		if len(summary.URLs) == 0 {
+			needsDetails = append(needsDetails, summary)
+			continue
+		}
+		candidates = append(candidates, onePasswordSummaryCandidates(summary, sites)...)
+	}
+	if len(needsDetails) == 0 {
+		return candidates, nil
+	}
+	input, err := json.Marshal(needsDetails)
+	if err != nil {
+		return nil, err
+	}
+	itemOutput, err := commandInput(ctx, p.path, nil, input, "item", "get", "-", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("read 1Password login metadata: %w", err)
+	}
+	items, err := decodeOnePasswordItems(itemOutput)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		matched := make(map[string]struct{})
+		for _, itemURL := range item.URLs {
+			domain := selectedDomain(itemURL.Href, sites)
+			if domain == "" {
+				continue
+			}
+			if _, exists := matched[domain]; exists {
+				continue
+			}
+			matched[domain] = struct{}{}
+			username, _, _ := onePasswordFields(item)
+			candidates = append(candidates, Candidate{Provider: "1password", ID: item.ID, VaultID: item.Vault.ID, Name: item.Title, Domain: domain, Username: username})
+		}
+	}
+	return candidates, nil
+}
+
+func (p *onePasswordProvider) Reveal(ctx context.Context, selected []Candidate) ([]Record, error) {
+	summaries := make([]onePasswordSummary, 0, len(selected))
+	seen := make(map[string]struct{}, len(selected))
+	for _, candidate := range selected {
+		key := candidate.VaultID + ":" + candidate.ID
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		var summary onePasswordSummary
+		summary.ID = candidate.ID
+		summary.Title = candidate.Name
+		summary.Vault.ID = candidate.VaultID
+		summaries = append(summaries, summary)
+	}
+	input, err := json.Marshal(summaries)
+	if err != nil {
+		return nil, err
+	}
+	itemOutput, err := commandInput(ctx, p.path, nil, input, "item", "get", "-", "--format", "json", "--reveal")
+	if err != nil {
+		return nil, fmt.Errorf("read approved 1Password logins: %w", err)
+	}
+	items, err := decodeOnePasswordItems(itemOutput)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string][]Candidate, len(selected))
+	for _, candidate := range selected {
+		key := candidate.VaultID + ":" + candidate.ID
+		byID[key] = append(byID[key], candidate)
+	}
+	records := make([]Record, 0, len(items))
+	for _, item := range items {
+		candidates, ok := byID[item.Vault.ID+":"+item.ID]
+		if !ok {
+			continue
+		}
+		username, password, totp := onePasswordFields(item)
+		for _, candidate := range candidates {
+			records = append(records, Record{Provider: "1password", ID: item.Vault.ID + ":" + item.ID, Name: item.Title, Domain: candidate.Domain, Username: username, Password: password, TOTPSecret: normalizeTOTP(totp)})
+		}
+	}
+	return deduplicate(records), nil
+}
+
+func (p *onePasswordProvider) personalSummaries(ctx context.Context) ([]onePasswordSummary, error) {
+	vaultList, err := command(ctx, p.path, nil, "vault", "list", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("authorize 1Password with Touch ID: %w", err)
+	}
+	vaultDetails, err := commandInput(ctx, p.path, nil, vaultList, "vault", "get", "-", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("read 1Password vault metadata: %w", err)
+	}
+	vaults, err := decodeOnePasswordVaults(vaultDetails)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]onePasswordSummary, 0)
+	for _, vault := range vaults {
+		if vault.ID == "" || !strings.EqualFold(vault.Type, "PERSONAL") {
+			continue
+		}
+		output, err := command(ctx, p.path, nil, "item", "list", "--categories", "Login", "--vault", vault.ID, "--long", "--format", "json")
+		if err != nil {
+			return nil, fmt.Errorf("list 1Password personal logins: %w", err)
+		}
+		var listed []onePasswordSummary
+		if err := json.Unmarshal(output, &listed); err != nil {
+			return nil, fmt.Errorf("decode 1Password login list: %w", err)
+		}
+		summaries = append(summaries, listed...)
+		if len(summaries) > 5000 {
+			return nil, fmt.Errorf("1Password has more than 5000 personal login items; narrow the vault before importing")
+		}
+	}
+	if len(summaries) == 0 {
+		return nil, fmt.Errorf("1Password has no personal login items")
+	}
+	return summaries, nil
+}
+
+func onePasswordSummaryCandidates(summary onePasswordSummary, sites []string) []Candidate {
+	result := make([]Candidate, 0)
+	seen := make(map[string]struct{})
+	for _, itemURL := range summary.URLs {
+		domain := selectedDomain(itemURL.Href, sites)
+		if domain == "" {
+			continue
+		}
+		if _, exists := seen[domain]; exists {
+			continue
+		}
+		seen[domain] = struct{}{}
+		result = append(result, Candidate{Provider: "1password", ID: summary.ID, VaultID: summary.Vault.ID, Name: summary.Title, Domain: domain})
+	}
+	return result
+}
+
+func decodeOnePasswordVaults(output []byte) ([]onePasswordVault, error) {
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	vaults := make([]onePasswordVault, 0)
+	for {
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			if err == io.EOF {
+				return vaults, nil
+			}
+			return nil, fmt.Errorf("decode 1Password vaults: %w", err)
+		}
+		if len(raw) > 0 && raw[0] == '[' {
+			var batch []onePasswordVault
+			if err := json.Unmarshal(raw, &batch); err != nil {
+				return nil, err
+			}
+			vaults = append(vaults, batch...)
+			continue
+		}
+		var vault onePasswordVault
+		if err := json.Unmarshal(raw, &vault); err != nil {
+			return nil, err
+		}
+		vaults = append(vaults, vault)
+	}
+}
+
+func decodeOnePasswordItems(output []byte) ([]onePasswordItem, error) {
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	items := make([]onePasswordItem, 0)
+	for {
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			if err == io.EOF {
+				return items, nil
+			}
+			return nil, fmt.Errorf("decode 1Password login: %w", err)
+		}
+		if len(raw) > 0 && raw[0] == '[' {
+			var batch []onePasswordItem
+			if err := json.Unmarshal(raw, &batch); err != nil {
+				return nil, fmt.Errorf("decode 1Password logins: %w", err)
+			}
+			items = append(items, batch...)
+			continue
+		}
+		var item onePasswordItem
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, fmt.Errorf("decode 1Password login: %w", err)
+		}
+		items = append(items, item)
+	}
+}
+
+func onePasswordFields(item onePasswordItem) (string, string, string) {
+	var username, password, totp string
+	for _, field := range item.Fields {
+		value, ok := field.Value.(string)
+		if !ok {
+			continue
+		}
+		switch {
+		case strings.EqualFold(field.Type, "OTP"):
+			totp = value
+		case strings.EqualFold(field.Purpose, "USERNAME"):
+			username = value
+		case strings.EqualFold(field.Purpose, "PASSWORD"):
+			password = value
+		}
+	}
+	return username, password, totp
+}

--- a/internal/passwordmanager/passwordmanager.go
+++ b/internal/passwordmanager/passwordmanager.go
@@ -40,6 +40,12 @@ type Provider interface {
 	Reveal(context.Context, []Candidate) ([]Record, error)
 }
 
+// InteractiveAuthorizer lets the CLI prepare a provider after local user consent.
+type InteractiveAuthorizer interface {
+	AuthorizationRequired(context.Context) (bool, error)
+	Authorize(context.Context) error
+}
+
 const maxCommandOutput = 16 << 20
 
 // Detect returns supported password-manager CLIs installed on this machine.

--- a/internal/passwordmanager/passwordmanager.go
+++ b/internal/passwordmanager/passwordmanager.go
@@ -1,0 +1,140 @@
+package passwordmanager
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Record is one login approved for import into Kernel Managed Auth.
+type Record struct {
+	Provider   string
+	ID         string
+	Name       string
+	Domain     string
+	Username   string
+	Password   string
+	TOTPSecret string
+}
+
+// Candidate is non-secret metadata used for local selection.
+type Candidate struct {
+	Provider string
+	ID       string
+	Name     string
+	Domain   string
+	Username string
+	VaultID  string
+}
+
+// Provider reads matching logins from a locally authorized password-manager CLI.
+type Provider interface {
+	Name() string
+	Candidates(context.Context, []string) ([]Candidate, error)
+	Reveal(context.Context, []Candidate) ([]Record, error)
+}
+
+const maxCommandOutput = 16 << 20
+
+// Detect returns supported password-manager CLIs installed on this machine.
+func Detect() []Provider {
+	providers := make([]Provider, 0, 2)
+	if path, err := exec.LookPath("bw"); err == nil {
+		providers = append(providers, &bitwardenProvider{path: path})
+	}
+	if path, err := exec.LookPath("op"); err == nil {
+		providers = append(providers, &onePasswordProvider{path: path})
+	}
+	return providers
+}
+
+func command(ctx context.Context, path string, environment map[string]string, args ...string) ([]byte, error) {
+	return commandInput(ctx, path, environment, nil, args...)
+}
+
+func commandInput(ctx context.Context, path string, environment map[string]string, input []byte, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, path, args...)
+	if input == nil {
+		cmd.Stdin = os.Stdin
+	} else {
+		cmd.Stdin = bytes.NewReader(input)
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	for key, value := range environment {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	output, readErr := io.ReadAll(io.LimitReader(stdout, maxCommandOutput+1))
+	if len(output) > maxCommandOutput {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("%s output exceeds 16 MiB", filepathBase(path))
+	}
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return nil, readErr
+	}
+	err = waitErr
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("%s %s: %w", filepathBase(path), strings.Join(args, " "), err)
+	}
+	return output, nil
+}
+
+func selectedDomain(value string, selected []string) string {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	host := strings.TrimPrefix(strings.ToLower(parsed.Hostname()), ".")
+	for _, domain := range selected {
+		if host == domain || strings.HasSuffix(host, "."+domain) || strings.HasSuffix(domain, "."+host) {
+			return domain
+		}
+	}
+	return ""
+}
+
+func deduplicate(records []Record) []Record {
+	seen := make(map[string]struct{}, len(records))
+	result := make([]Record, 0, len(records))
+	for _, record := range records {
+		key := record.Provider + "\x00" + record.ID + "\x00" + record.Domain
+		if record.Domain == "" || record.ID == "" || (record.Username == "" && record.Password == "") {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, record)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Domain == result[j].Domain {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Domain < result[j].Domain
+	})
+	return result
+}
+
+func filepathBase(path string) string {
+	parts := strings.Split(path, string(os.PathSeparator))
+	return parts[len(parts)-1]
+}

--- a/internal/passwordmanager/passwordmanager_test.go
+++ b/internal/passwordmanager/passwordmanager_test.go
@@ -1,0 +1,78 @@
+package passwordmanager
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectedDomainMatchesOnlyApprovedSites(t *testing.T) {
+	assert.Equal(t, "github.com", selectedDomain("https://api.github.com/login", []string{"github.com"}))
+	assert.Empty(t, selectedDomain("https://notgithub.com", []string{"github.com"}))
+}
+
+func TestNormalizeTOTPAcceptsSupportedSecret(t *testing.T) {
+	assert.Equal(t, "JBSWY3DPEHPK3PXP", normalizeTOTP("otpauth://totp/Test?secret=JBSWY3DPEHPK3PXP&algorithm=SHA1"))
+	assert.Empty(t, normalizeTOTP("otpauth://totp/Test?secret=JBSWY3DPEHPK3PXP&algorithm=SHA256"))
+}
+
+func TestDecodeOnePasswordItemsAcceptsArrayAndStream(t *testing.T) {
+	array, err := decodeOnePasswordItems([]byte(`[{"id":"one"},{"id":"two"}]`))
+	require.NoError(t, err)
+	require.Len(t, array, 2)
+	stream, err := decodeOnePasswordItems([]byte("{\"id\":\"one\"}\n{\"id\":\"two\"}\n"))
+	require.NoError(t, err)
+	require.Len(t, stream, 2)
+}
+
+func TestDecodeOnePasswordVaultsAcceptsBulkStream(t *testing.T) {
+	vaults, err := decodeOnePasswordVaults([]byte("{\"id\":\"personal\",\"type\":\"PERSONAL\"}\n{\"id\":\"shared\",\"type\":\"BUSINESS\"}\n"))
+	require.NoError(t, err)
+	require.Len(t, vaults, 2)
+	assert.Equal(t, "PERSONAL", vaults[0].Type)
+}
+
+func TestDeduplicateRejectsSharedOrEmptyRecords(t *testing.T) {
+	records := deduplicate([]Record{
+		{Provider: "bitwarden", ID: "one", Domain: "example.com", Username: "me"},
+		{Provider: "bitwarden", ID: "one", Domain: "example.com", Username: "me"},
+		{Provider: "bitwarden", ID: "two", Domain: "", Username: "me"},
+	})
+	require.Len(t, records, 1)
+	assert.Equal(t, "one", records[0].ID)
+}
+
+func TestDeduplicatePreservesOneItemForMultipleDomains(t *testing.T) {
+	records := deduplicate([]Record{
+		{Provider: "bitwarden", ID: "one", Domain: "accounts.example.com", Username: "me"},
+		{Provider: "bitwarden", ID: "one", Domain: "app.example.com", Username: "me"},
+	})
+	require.Len(t, records, 2)
+}
+
+func TestBitwardenCandidateWireTypeCannotRetainSecrets(t *testing.T) {
+	login, ok := reflect.TypeOf(bitwardenCandidateItem{}).FieldByName("Login")
+	require.True(t, ok)
+	loginType := login.Type.Elem()
+	_, hasPassword := loginType.FieldByName("Password")
+	_, hasTOTP := loginType.FieldByName("TOTP")
+	assert.False(t, hasPassword)
+	assert.False(t, hasTOTP)
+}
+
+func TestOnePasswordLongSummaryCanMatchWithoutItemReveal(t *testing.T) {
+	var summary onePasswordSummary
+	summary.ID = "item"
+	summary.Title = "Example"
+	summary.Vault.ID = "personal"
+	summary.URLs = append(summary.URLs, struct {
+		Href string `json:"href"`
+	}{Href: "https://login.example.com"})
+
+	candidates := onePasswordSummaryCandidates(summary, []string{"example.com"})
+	require.Len(t, candidates, 1)
+	assert.Equal(t, "item", candidates[0].ID)
+	assert.Equal(t, "example.com", candidates[0].Domain)
+}

--- a/internal/passwordmanager/passwordmanager_test.go
+++ b/internal/passwordmanager/passwordmanager_test.go
@@ -1,6 +1,8 @@
 package passwordmanager
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -60,6 +62,37 @@ func TestBitwardenCandidateWireTypeCannotRetainSecrets(t *testing.T) {
 	_, hasTOTP := loginType.FieldByName("TOTP")
 	assert.False(t, hasPassword)
 	assert.False(t, hasTOTP)
+}
+
+func TestBitwardenUnlockKeepsSessionInProviderMemory(t *testing.T) {
+	t.Setenv("BW_SESSION", "")
+	path := filepath.Join(t.TempDir(), "bw")
+	script := `#!/bin/sh
+case "$1" in
+  status)
+    if [ "$BW_SESSION" = "temporary-session" ]; then
+      printf '{"status":"unlocked"}'
+    else
+      printf '{"status":"locked"}'
+    fi
+    ;;
+  unlock)
+    printf 'temporary-session'
+    ;;
+  *) exit 1 ;;
+esac
+`
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o700))
+	provider := &bitwardenProvider{path: path}
+
+	required, err := provider.AuthorizationRequired(t.Context())
+	require.NoError(t, err)
+	require.True(t, required)
+	require.NoError(t, provider.Authorize(t.Context()))
+	required, err = provider.AuthorizationRequired(t.Context())
+	require.NoError(t, err)
+	assert.False(t, required)
+	assert.Empty(t, os.Getenv("BW_SESSION"))
 }
 
 func TestOnePasswordLongSummaryCanMatchWithoutItemReveal(t *testing.T) {

--- a/internal/passwordmanager/totp.go
+++ b/internal/passwordmanager/totp.go
@@ -1,0 +1,35 @@
+package passwordmanager
+
+import (
+	"encoding/base32"
+	"net/url"
+	"strings"
+)
+
+func normalizeTOTP(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToLower(value), "otpauth://") {
+		parsed, err := url.Parse(value)
+		if err != nil || !strings.EqualFold(parsed.Host, "totp") {
+			return ""
+		}
+		if algorithm := parsed.Query().Get("algorithm"); algorithm != "" && !strings.EqualFold(algorithm, "SHA1") {
+			return ""
+		}
+		if digits := parsed.Query().Get("digits"); digits != "" && digits != "6" {
+			return ""
+		}
+		if period := parsed.Query().Get("period"); period != "" && period != "30" {
+			return ""
+		}
+		value = parsed.Query().Get("secret")
+	}
+	value = strings.ToUpper(strings.ReplaceAll(value, " ", ""))
+	if value == "" {
+		return ""
+	}
+	if _, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(strings.TrimRight(value, "=")); err != nil {
+		return ""
+	}
+	return value
+}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 
+	"atomicgo.dev/keyboard/keys"
 	"github.com/pterm/pterm"
 	"golang.org/x/term"
 )
@@ -177,13 +178,18 @@ func (p Prompter) MultiSelect(what, hint, promptText string, options, defaults [
 	if !p.CanPrompt() {
 		return nil, ErrInputRequired(what, hint)
 	}
+	return newMultiSelectPrinter(promptText, options, defaults).Show()
+}
+
+func newMultiSelectPrinter(promptText string, options, defaults []string) *pterm.InteractiveMultiselectPrinter {
 	return pterm.DefaultInteractiveMultiselect.
 		WithOptions(options).
 		WithDefaultOptions(defaults).
 		WithDefaultText(promptText).
-		WithFilter(true).
-		WithMaxHeight(min(len(options), 12)).
-		Show()
+		WithFilter(false).
+		WithKeySelect(keys.Space).
+		WithKeyConfirm(keys.Enter).
+		WithMaxHeight(min(len(options), 12))
 }
 
 // TextInput shows a free-text prompt and returns the entered text. When the

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -150,13 +150,21 @@ func ErrInputsRequired(problems []string) error {
 // reports the choice. When the Prompter cannot prompt it fails fast with
 // ErrConfirmationRequired(action) instead.
 func (p Prompter) Confirm(action, promptText string) (bool, error) {
+	return p.ConfirmDefault(action, promptText, false)
+}
+
+// ConfirmDefault shows a yes/no confirmation with the requested default.
+func (p Prompter) ConfirmDefault(action, promptText string, defaultValue bool) (bool, error) {
 	if !p.CanPrompt() {
 		return false, ErrConfirmationRequired(action)
 	}
+	return newConfirmPrinter(promptText, defaultValue).Show()
+}
+
+func newConfirmPrinter(promptText string, defaultValue bool) *pterm.InteractiveConfirmPrinter {
 	return pterm.DefaultInteractiveConfirm.
 		WithDefaultText(promptText).
-		WithDefaultValue(false).
-		Show()
+		WithDefaultValue(defaultValue)
 }
 
 // Select shows a select prompt over options and returns the chosen option.

--- a/pkg/interactive/interactive_test.go
+++ b/pkg/interactive/interactive_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"atomicgo.dev/keyboard/keys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -109,4 +110,13 @@ func TestPromptPrimitivesFailFastWhenNonInteractive(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "widget name")
 	assert.Contains(t, err.Error(), "pass --name")
+}
+
+func TestMultiSelectUsesConventionalKeys(t *testing.T) {
+	t.Parallel()
+	printer := newMultiSelectPrinter("Choose websites", []string{"example.com"}, nil)
+
+	assert.False(t, printer.Filter)
+	assert.Equal(t, keys.Space, printer.KeySelect)
+	assert.Equal(t, keys.Enter, printer.KeyConfirm)
 }

--- a/pkg/interactive/interactive_test.go
+++ b/pkg/interactive/interactive_test.go
@@ -120,3 +120,9 @@ func TestMultiSelectUsesConventionalKeys(t *testing.T) {
 	assert.Equal(t, keys.Space, printer.KeySelect)
 	assert.Equal(t, keys.Enter, printer.KeyConfirm)
 }
+
+func TestConfirmPrinterUsesRequestedDefault(t *testing.T) {
+	t.Parallel()
+	assert.False(t, newConfirmPrinter("Delete it?", false).DefaultValue)
+	assert.True(t, newConfirmPrinter("Unlock it?", true).DefaultValue)
+}


### PR DESCRIPTION
## What

Adds the second CLI import layer on top of #223:

- discovers matching Bitwarden and 1Password login metadata for the 5–10 selected sites
- unlocks Bitwarden interactively for this import when the local vault is locked
- asks the user to choose at most one account per site
- reveals only approved secrets after the browser profile has been created
- creates or reconciles Kernel credentials and Managed Auth connections
- imports supported TOTP secrets
- optionally installs a small Managed Auth skill into detected local agent directories
- selects the destination project in Terminal when the account has multiple projects

## Why

The customer outcome is one local wizard: choose a project, import useful browser cookies, approve a small set of matching accounts, and leave agents with profile state plus Managed Auth connections. It avoids uploading an entire vault, requiring hundreds of manual Managed Auth setups, or copying a project ID from the dashboard.

## How

- Bitwarden authorization stays local. Its session key remains in the CLI process and is passed to child commands through their environment, never argv or shell state.
- Bitwarden uses site-scoped metadata queries and fetches only approved item IDs.
- 1Password uses personal-vault metadata, prefers long list records containing URLs, and reveals only selected item IDs.
- Provisioning uses stable provider item identities, checks existing profile/domain connections first, and reconciles response-loss retries.
- Project selection pages active projects, auto-selects the only project, and prompts only when there are multiple.
- Terminal option text is single-line, ANSI/control sanitized, and bounded by display-cell width to avoid wrapped selector redraw artifacts.
- Agent-skill installation rejects symlinks and customized existing skills and writes atomically.

## Verification

- affected package tests: `go test ./internal/passwordmanager ./internal/agentskills ./internal/browserimport ./cmd -count=1`
- affected package vet: `go vet ./internal/passwordmanager ./internal/agentskills ./internal/browserimport ./cmd`
- focused normal and race tests for password managers, browser import, Managed Auth reconciliation, TOTP removal, agent-skill installation, project selection, and terminal rendering
- independent Dave Cheney, eBlog, and thermonuclear reviews; all actionable findings addressed

## Stack

- Parent: #223
- This PR is API-deployment dependent on kernel/kernel#3244 for Idempotency-Key response-loss recovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Handles passwords and TOTP from local vaults, creates/updates cloud credentials, and writes files into agent skill directories. Failures in selection, reveal, or reconciliation can leak or overwrite auth state.
> 
> **Overview**
> `kernel profiles import-local` can now match Bitwarden/1Password logins for the selected sites, create Kernel credentials plus Managed Auth connections (including supported TOTP), and optionally install a Managed Auth agent skill.
> 
> Secrets are revealed only after the browser profile exists, and only for user-approved items (at most one login per site). Bitwarden can unlock in-process; 1Password is limited to personal vaults. Provisioning uses stable import names, refreshes existing connections, and refuses to overwrite a domain already bound to another credential.
> 
> The wizard also prompts for the destination project when several are active, counts cookies before site selection, retries browser-import create with an idempotency key, and writes `SKILL.md` atomically while refusing symlinks and customized skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd122dad623e473593d736a11b98751bf4b9ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->