### PR TITLE
Add dashboard connector for local browser imports

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,12 @@ brews:
     directory: Formula
     description: "Kernel CLI"
     homepage: "https://github.com/kernel/cli"
+    post_install: |
+      if OS.mac?
+        unless quiet_system bin/"kernel", "connector", "install"
+          opoo "Kernel CLI installed, but kernel:// registration failed. Run `kernel connector install` to retry."
+        end
+      end
     test: |
       system "#{bin}/kernel", "--version"
 

--- a/cmd/browser_import_managed_auth.go
+++ b/cmd/browser_import_managed_auth.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,8 +14,52 @@ import (
 	"github.com/kernel/kernel-go-sdk/packages/pagination"
 )
 
+type managedAuthCapacity struct {
+	remaining int
+	unlimited bool
+}
+
+type orgLimitsGetter interface {
+	Get(context.Context, ...option.RequestOption) (*kernel.OrgLimits, error)
+}
+
+func loadManagedAuthCapacity(ctx context.Context, limits orgLimitsGetter) (managedAuthCapacity, error) {
+	orgLimits, err := limits.Get(ctx)
+	if err != nil {
+		return managedAuthCapacity{}, err
+	}
+	return decodeManagedAuthCapacity(orgLimits.RawJSON())
+}
+
+func decodeManagedAuthCapacity(raw string) (managedAuthCapacity, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return managedAuthCapacity{}, fmt.Errorf("decode organization limits: %w", err)
+	}
+	maxRaw, hasMax := fields["max_auth_connections"]
+	usedRaw, hasUsed := fields["auth_connections_used"]
+	if !hasMax || !hasUsed {
+		return managedAuthCapacity{}, fmt.Errorf("Kernel API does not expose Managed Auth capacity; deploy the organization entitlements API first")
+	}
+	if string(maxRaw) == "null" {
+		return managedAuthCapacity{unlimited: true}, nil
+	}
+	var maxConnections, usedConnections int
+	if err := json.Unmarshal(maxRaw, &maxConnections); err != nil {
+		return managedAuthCapacity{}, fmt.Errorf("decode max auth connections: %w", err)
+	}
+	if err := json.Unmarshal(usedRaw, &usedConnections); err != nil {
+		return managedAuthCapacity{}, fmt.Errorf("decode used auth connections: %w", err)
+	}
+	if maxConnections < 0 || usedConnections < 0 {
+		return managedAuthCapacity{}, fmt.Errorf("Kernel API returned invalid Managed Auth capacity")
+	}
+	return managedAuthCapacity{remaining: max(0, maxConnections-usedConnections)}, nil
+}
+
 type managedAuthProvisioner interface {
 	Provision(context.Context, string, []passwordmanager.Record) ([]string, error)
+	Existing(context.Context, string, []passwordmanager.Candidate) (map[string]bool, error)
 }
 
 type kernelManagedAuthProvisioner struct {
@@ -81,6 +126,35 @@ func (p kernelManagedAuthProvisioner) Provision(ctx context.Context, profileName
 	return connectionIDs, nil
 }
 
+func (p kernelManagedAuthProvisioner) Existing(ctx context.Context, profileName string, candidates []passwordmanager.Candidate) (map[string]bool, error) {
+	existingNames := make(map[string]struct{})
+	const pageSize = 100
+	for offset := int64(0); ; offset += pageSize {
+		page, err := p.connections.List(ctx, kernel.AuthConnectionListParams{
+			ProfileName: kernel.Opt(profileName), Limit: kernel.Opt(int64(pageSize)), Offset: kernel.Opt(offset),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if page == nil {
+			break
+		}
+		for _, connection := range page.Items {
+			existingNames[connection.Credential.Name] = struct{}{}
+		}
+		if len(page.Items) < pageSize {
+			break
+		}
+	}
+
+	result := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		name := importedCredentialNameFor(candidate.Provider, candidateImportID(candidate), candidate.Domain)
+		_, result[candidateKey(candidate)] = existingNames[name]
+	}
+	return result, nil
+}
+
 type connectionLookup struct {
 	match    *kernel.ManagedAuth
 	conflict *kernel.ManagedAuth
@@ -129,13 +203,28 @@ func (p kernelManagedAuthProvisioner) refreshCredential(ctx context.Context, nam
 var importedCredentialCharacters = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 
 func importedCredentialName(record passwordmanager.Record) string {
-	digest := sha256.Sum256([]byte(record.Provider + "\x00" + record.ID))
-	prefix := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower("import-"+record.Provider), "-"), "-")
-	domain := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower(record.Domain), "-"), "-")
+	return importedCredentialNameFor(record.Provider, record.ID, record.Domain)
+}
+
+func importedCredentialNameFor(provider, id, recordDomain string) string {
+	digest := sha256.Sum256([]byte(provider + "\x00" + id))
+	prefix := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower("import-"+provider), "-"), "-")
+	domain := strings.Trim(importedCredentialCharacters.ReplaceAllString(strings.ToLower(recordDomain), "-"), "-")
 	suffix := fmt.Sprintf("-%x", digest[:5])
 	maxDomainLength := 255 - len(prefix) - len(suffix) - 1
 	if len(domain) > maxDomainLength {
 		domain = strings.Trim(domain[:maxDomainLength], "-")
 	}
 	return prefix + "-" + domain + suffix
+}
+
+func candidateKey(candidate passwordmanager.Candidate) string {
+	return candidate.Provider + "\x00" + candidateImportID(candidate) + "\x00" + candidate.Domain
+}
+
+func candidateImportID(candidate passwordmanager.Candidate) string {
+	if candidate.Provider == "1password" && candidate.VaultID != "" {
+		return candidate.VaultID + ":" + candidate.ID
+	}
+	return candidate.ID
 }

--- a/cmd/browser_import_managed_auth_test.go
+++ b/cmd/browser_import_managed_auth_test.go
@@ -146,6 +146,20 @@ func TestImportedCredentialNameFitsAPINameLimit(t *testing.T) {
 	assert.Regexp(t, `-[a-f0-9]{10}$`, name)
 }
 
+func TestManagedAuthExistingUsesOnePasswordVaultIdentity(t *testing.T) {
+	candidate := passwordmanager.Candidate{Provider: "1password", VaultID: "vault", ID: "item", Domain: "example.com"}
+	name := importedCredentialName(passwordmanager.Record{Provider: "1password", ID: "vault:item", Domain: "example.com"})
+	provisioner := kernelManagedAuthProvisioner{connections: fakeImportedConnections{
+		listFunc: func(kernel.AuthConnectionListParams) (*pagination.OffsetPagination[kernel.ManagedAuth], error) {
+			return &pagination.OffsetPagination[kernel.ManagedAuth]{Items: []kernel.ManagedAuth{{Credential: kernel.ManagedAuthCredential{Name: name}}}}, nil
+		},
+	}}
+
+	existing, err := provisioner.Existing(t.Context(), "profile", []passwordmanager.Candidate{candidate})
+	require.NoError(t, err)
+	assert.True(t, existing[candidateKey(candidate)])
+}
+
 func TestManagedAuthProvisionFindsMatchingConnectionAfterSiblingAccount(t *testing.T) {
 	record := passwordmanager.Record{Provider: "bitwarden", ID: "item", Domain: "example.com", Username: "me"}
 	name := importedCredentialName(record)

--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -54,7 +54,7 @@ func runConnectorOpen(cmd *cobra.Command, args []string) error {
 	}
 	pterm.Info.Println("Browser import requested from a kernel:// link")
 	input := ProfilesImportLocalInput{
-		Count:           5,
+		Count:           10,
 		Days:            30,
 		ProjectID:       link.ProjectID,
 		Version:         metadata.Version,

--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -54,7 +54,6 @@ func runConnectorOpen(cmd *cobra.Command, args []string) error {
 	}
 	pterm.Info.Println("Browser import requested from a kernel:// link")
 	input := ProfilesImportLocalInput{
-		Count:           10,
 		Days:            30,
 		ProjectID:       link.ProjectID,
 		Version:         metadata.Version,

--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kernel/cli/internal/connector"
+	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/util"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var connectorCmd = &cobra.Command{
+	Use:   "connector",
+	Short: "Connect Kernel dashboard actions to the local CLI",
+}
+
+var connectorOpenCmd = &cobra.Command{
+	Use:    "open <kernel-url>",
+	Short:  "Open a Kernel dashboard action",
+	Args:   cobra.ExactArgs(1),
+	Hidden: true,
+	RunE:   runConnectorOpen,
+}
+
+var connectorInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Register kernel:// links for this user",
+	Args:  cobra.NoArgs,
+	RunE:  runConnectorInstall,
+}
+
+func init() {
+	connectorCmd.AddCommand(connectorOpenCmd, connectorInstallCmd)
+	rootCmd.AddCommand(connectorCmd)
+}
+
+func runConnectorOpen(cmd *cobra.Command, args []string) error {
+	link, err := connector.ParseBrowserImportLink(args[0])
+	if err != nil {
+		return err
+	}
+	if err := authenticateConnector(cmd); err != nil {
+		return err
+	}
+	pterm.Info.Println("Browser import requested from a kernel:// link")
+	return runProfilesImportLocalWithInput(cmd, ProfilesImportLocalInput{
+		Count:           5,
+		Days:            30,
+		ProjectID:       link.ProjectID,
+		Version:         metadata.Version,
+		WaitTimeout:     30 * time.Minute,
+		DashboardLaunch: true,
+	})
+}
+
+func authenticateConnector(cmd *cobra.Command) error {
+	client, err := auth.GetAuthenticatedClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
+	if err != nil {
+		pterm.Info.Println("Sign in to continue this browser import")
+		if err := runLogin(cmd, nil); err != nil {
+			return err
+		}
+		client, err = auth.GetAuthenticatedClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
+		if err != nil {
+			return fmt.Errorf("authentication required: %w", err)
+		}
+	}
+	cmd.SetContext(context.WithValue(cmd.Context(), util.KernelClientKey, *client))
+	return nil
+}
+
+func runConnectorInstall(cmd *cobra.Command, _ []string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	executable, err := stableKernelExecutable()
+	if err != nil {
+		return err
+	}
+	installed, err := connector.Install(cmd.Context(), home, executable)
+	if err != nil {
+		return err
+	}
+	pterm.Success.Printf("Kernel Connector installed at %s\n", installed)
+	return nil
+}
+
+func stableKernelExecutable() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("find Kernel executable: %w", err)
+	}
+	return stableExecutablePath(executable), nil
+}
+
+func stableExecutablePath(executable string) string {
+	const cellarSegment = "/Cellar/"
+	if index := strings.Index(filepath.ToSlash(executable), cellarSegment); index >= 0 {
+		return filepath.Join(executable[:index], "bin", "kernel")
+	}
+	return executable
+}

--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,9 @@ import (
 
 	"github.com/kernel/cli/internal/connector"
 	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/cli/pkg/interactive"
 	"github.com/kernel/cli/pkg/util"
+	"github.com/kernel/kernel-go-sdk"
 	"github.com/kernel/kernel-go-sdk/option"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -50,24 +53,114 @@ func runConnectorOpen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	pterm.Info.Println("Browser import requested from a kernel:// link")
-	return runProfilesImportLocalWithInput(cmd, ProfilesImportLocalInput{
+	input := ProfilesImportLocalInput{
 		Count:           5,
 		Days:            30,
 		ProjectID:       link.ProjectID,
 		Version:         metadata.Version,
 		WaitTimeout:     30 * time.Minute,
 		DashboardLaunch: true,
-	})
+	}
+	project, err := validateConnectorProject(cmd, input.ProjectID)
+	if err != nil {
+		recovered, recoveryErr := recoverConnectorAuthentication(
+			cmd,
+			err,
+			interactive.NewPrompter().ConfirmDefault,
+			runLoginWithForce,
+		)
+		if recoveryErr != nil {
+			return recoveryErr
+		}
+		if !recovered {
+			return err
+		}
+		if err := authenticateConnector(cmd); err != nil {
+			return err
+		}
+		project, err = validateConnectorProject(cmd, input.ProjectID)
+		if err != nil {
+			return err
+		}
+	}
+	input.Project = &project
+	return runProfilesImportLocalWithInput(cmd, input)
+}
+
+type connectorConfirm func(action, prompt string, defaultValue bool) (bool, error)
+type connectorLogin func(*cobra.Command, bool) error
+type connectorClientFactory func(...option.RequestOption) (*kernel.Client, error)
+
+func recoverConnectorAuthentication(cmd *cobra.Command, cause error, confirm connectorConfirm, login connectorLogin) (bool, error) {
+	if !dashboardProjectAuthRecovery(cause) {
+		return false, nil
+	}
+	hasAPIKey := os.Getenv("KERNEL_API_KEY") != ""
+	prompt := "The current Kernel account cannot access this project. Switch accounts with browser sign-in?"
+	if hasAPIKey {
+		prompt = "Kernel API key is invalid, disabled, or cannot access this project. Continue with browser sign-in instead?"
+	}
+	proceed, err := confirm(
+		"continue with browser sign-in",
+		prompt,
+		true,
+	)
+	if err != nil {
+		return false, err
+	}
+	if !proceed {
+		if !hasAPIKey {
+			return false, fmt.Errorf("account switch declined; run `kernel login --force` when you are ready to switch accounts, then open the import again")
+		}
+		return false, fmt.Errorf("browser sign-in declined; unset KERNEL_API_KEY or replace it with a valid key, then open the import again")
+	}
+	if hasAPIKey {
+		if err := os.Unsetenv("KERNEL_API_KEY"); err != nil {
+			return false, fmt.Errorf("ignore invalid KERNEL_API_KEY for this import: %w", err)
+		}
+	}
+	pterm.Info.Println("Using browser sign-in for this import; your shell environment was not changed")
+	if err := login(cmd, true); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func validateConnectorProject(cmd *cobra.Command, projectID string) (kernel.Project, error) {
+	client := getKernelClient(cmd)
+	return chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), projectID, true)
 }
 
 func authenticateConnector(cmd *cobra.Command) error {
-	client, err := auth.GetAuthenticatedClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
+	return authenticateConnectorWith(
+		cmd,
+		interactive.NewPrompter().ConfirmDefault,
+		runLoginWithForce,
+		auth.GetAuthenticatedClient,
+	)
+}
+
+func authenticateConnectorWith(cmd *cobra.Command, confirm connectorConfirm, login connectorLogin, getClient connectorClientFactory) error {
+	client, err := getClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
 	if err != nil {
-		pterm.Info.Println("Sign in to continue this browser import")
-		if err := runLogin(cmd, nil); err != nil {
+		if !errors.Is(err, auth.ErrAuthenticationRequired) {
 			return err
 		}
-		client, err = auth.GetAuthenticatedClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
+		proceed, promptErr := confirm(
+			"sign in to continue this browser import",
+			"Sign in to Kernel to continue this browser import?",
+			true,
+		)
+		if promptErr != nil {
+			return promptErr
+		}
+		if !proceed {
+			return fmt.Errorf("Kernel sign-in is required to continue this browser import")
+		}
+		if err := login(cmd, false); err != nil {
+			return err
+		}
+		client, err = getClient(option.WithHeader("X-Kernel-Cli-Version", metadata.Version))
 		if err != nil {
 			return fmt.Errorf("authentication required: %w", err)
 		}

--- a/cmd/connector_test.go
+++ b/cmd/connector_test.go
@@ -1,9 +1,17 @@
 package cmd
 
 import (
+	"context"
+	"net/http"
+	"os"
 	"testing"
 
+	"github.com/kernel/cli/pkg/auth"
+	"github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStableExecutablePathUsesHomebrewSymlink(t *testing.T) {
@@ -11,4 +19,187 @@ func TestStableExecutablePathUsesHomebrewSymlink(t *testing.T) {
 	assert.Equal(t, "/opt/homebrew/bin/kernel", stableExecutablePath("/opt/homebrew/Cellar/kernel/1.2.3/bin/kernel"))
 	assert.Equal(t, "/usr/local/bin/kernel", stableExecutablePath("/usr/local/Cellar/kernel/1.2.3/bin/kernel"))
 	assert.Equal(t, "/Users/me/bin/kernel", stableExecutablePath("/Users/me/bin/kernel"))
+}
+
+func TestRecoverConnectorInvalidAPIKeyWithOAuth(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "disabled")
+	confirmed := false
+	loggedIn := false
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		&kernel.Error{StatusCode: http.StatusUnauthorized},
+		func(action, prompt string, defaultValue bool) (bool, error) {
+			confirmed = true
+			assert.Contains(t, action, "browser sign-in")
+			assert.Contains(t, prompt, "API key is invalid")
+			assert.True(t, defaultValue)
+			return true, nil
+		},
+		func(_ *cobra.Command, force bool) error {
+			loggedIn = true
+			assert.True(t, force)
+			assert.Empty(t, os.Getenv("KERNEL_API_KEY"))
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, recovered)
+	assert.True(t, confirmed)
+	assert.True(t, loggedIn)
+	assert.Empty(t, os.Getenv("KERNEL_API_KEY"))
+}
+
+func TestRecoverConnectorWrongOAuthAccount(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "")
+	forced := false
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		errRequestedProjectUnavailable,
+		func(_ string, prompt string, defaultValue bool) (bool, error) {
+			assert.Contains(t, prompt, "current Kernel account")
+			assert.True(t, defaultValue)
+			return true, nil
+		},
+		func(_ *cobra.Command, force bool) error {
+			forced = force
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, recovered)
+	assert.True(t, forced)
+}
+
+func TestRecoverConnectorWrongOAuthAccountDeclineGivesAccountGuidance(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "")
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		errRequestedProjectUnavailable,
+		func(string, string, bool) (bool, error) { return false, nil },
+		func(*cobra.Command, bool) error { return nil },
+	)
+
+	assert.False(t, recovered)
+	require.ErrorContains(t, err, "kernel login --force")
+	assert.NotContains(t, err.Error(), "unset KERNEL_API_KEY")
+}
+
+func TestAuthenticateConnectorAsksToLoginWhenCredentialsAreMissing(t *testing.T) {
+	clientCalls := 0
+	confirmed := false
+	loggedIn := false
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := authenticateConnectorWith(
+		cmd,
+		func(action, prompt string, defaultValue bool) (bool, error) {
+			confirmed = true
+			assert.Contains(t, action, "sign in")
+			assert.Contains(t, prompt, "Sign in to Kernel")
+			assert.True(t, defaultValue)
+			return true, nil
+		},
+		func(_ *cobra.Command, force bool) error {
+			loggedIn = true
+			assert.False(t, force)
+			return nil
+		},
+		func(...option.RequestOption) (*kernel.Client, error) {
+			clientCalls++
+			if clientCalls == 1 {
+				return nil, auth.ErrAuthenticationRequired
+			}
+			client := kernel.NewClient()
+			return &client, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+	assert.True(t, loggedIn)
+	assert.Equal(t, 2, clientCalls)
+}
+
+func TestAuthenticateConnectorPreservesNonAuthFailure(t *testing.T) {
+	prompted := false
+	want := assert.AnError
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := authenticateConnectorWith(
+		cmd,
+		func(string, string, bool) (bool, error) {
+			prompted = true
+			return true, nil
+		},
+		func(*cobra.Command, bool) error {
+			t.Fatal("login must not run for a credential storage failure")
+			return nil
+		},
+		func(...option.RequestOption) (*kernel.Client, error) { return nil, want },
+	)
+
+	require.ErrorIs(t, err, want)
+	assert.False(t, prompted)
+}
+
+func TestRecoverConnectorAPIKeyDoesNotHideNonAuthFailure(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "present")
+	prompted := false
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		&kernel.Error{StatusCode: http.StatusInternalServerError},
+		func(string, string, bool) (bool, error) {
+			prompted = true
+			return true, nil
+		},
+		func(*cobra.Command, bool) error {
+			t.Fatal("login must not run for a non-authentication failure")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, recovered)
+	assert.False(t, prompted)
+	assert.Equal(t, "present", os.Getenv("KERNEL_API_KEY"))
+}
+
+func TestRecoverConnectorAPIKeyDeclinePreservesEnvironment(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "disabled")
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		&kernel.Error{StatusCode: http.StatusUnauthorized},
+		func(string, string, bool) (bool, error) { return false, nil },
+		func(*cobra.Command, bool) error {
+			t.Fatal("login must not run after the user declines")
+			return nil
+		},
+	)
+
+	assert.False(t, recovered)
+	require.ErrorContains(t, err, "browser sign-in declined")
+	assert.Equal(t, "disabled", os.Getenv("KERNEL_API_KEY"))
+}
+
+func TestRecoverConnectorAPIKeyStopsAfterCanceledLogin(t *testing.T) {
+	t.Setenv("KERNEL_API_KEY", "disabled")
+
+	recovered, err := recoverConnectorAuthentication(
+		&cobra.Command{},
+		&kernel.Error{StatusCode: http.StatusUnauthorized},
+		func(string, string, bool) (bool, error) { return true, nil },
+		func(*cobra.Command, bool) error { return errLoginCanceled },
+	)
+
+	assert.False(t, recovered)
+	require.ErrorIs(t, err, errLoginCanceled)
 }

--- a/cmd/connector_test.go
+++ b/cmd/connector_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStableExecutablePathUsesHomebrewSymlink(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "/opt/homebrew/bin/kernel", stableExecutablePath("/opt/homebrew/Cellar/kernel/1.2.3/bin/kernel"))
+	assert.Equal(t, "/usr/local/bin/kernel", stableExecutablePath("/usr/local/Cellar/kernel/1.2.3/bin/kernel"))
+	assert.Equal(t, "/Users/me/bin/kernel", stableExecutablePath("/Users/me/bin/kernel"))
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -12,6 +13,8 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
+
+var errLoginCanceled = errors.New("Kernel login canceled")
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
@@ -28,7 +31,18 @@ func init() {
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
+	err := runLoginFlow(cmd, force, false)
+	if errors.Is(err, errLoginCanceled) {
+		return nil
+	}
+	return err
+}
 
+func runLoginWithForce(cmd *cobra.Command, force bool) error {
+	return runLoginFlow(cmd, force, true)
+}
+
+func runLoginFlow(cmd *cobra.Command, force, requireSavedTokens bool) error {
 	// Check if already logged in (unless force flag is used)
 	if !force {
 		if tokens, err := auth.LoadTokens(); err == nil && !tokens.IsExpired() {
@@ -64,7 +78,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		// Handle common error cases with helpful messages
 		if ctx.Err() == context.Canceled {
 			pterm.Info.Println("Authentication cancelled by user")
-			return nil
+			return errLoginCanceled
 		}
 
 		return fmt.Errorf("authentication failed: %w", err)
@@ -73,14 +87,23 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	spinner.Success("Authentication successful!")
 
 	// Save tokens securely
-	if err := auth.SaveTokens(tokens); err != nil {
-		pterm.Warning.Printf("Authentication succeeded but failed to save credentials: %v\n", err)
-		pterm.Warning.Println("You may need to re-authenticate on your next CLI usage")
-		return nil
+	if err := saveLoginTokens(tokens, requireSavedTokens, auth.SaveTokens); err != nil {
+		return err
 	}
 
 	pterm.Success.Println("✓ Successfully authenticated with Kernel!")
 	pterm.Info.Println("You can now use other Kernel CLI commands without setting KERNEL_API_KEY")
 
+	return nil
+}
+
+func saveLoginTokens(tokens *auth.TokenStorage, required bool, save func(*auth.TokenStorage) error) error {
+	if err := save(tokens); err != nil {
+		pterm.Warning.Printf("Authentication succeeded but failed to save credentials: %v\n", err)
+		if required {
+			return fmt.Errorf("save authenticated session: %w", err)
+		}
+		pterm.Warning.Println("You may need to re-authenticate on your next CLI usage")
+	}
 	return nil
 }

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kernel/cli/pkg/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectorLoginRequiresSavedTokens(t *testing.T) {
+	want := errors.New("storage unavailable")
+
+	err := saveLoginTokens(&auth.TokenStorage{}, true, func(*auth.TokenStorage) error { return want })
+
+	require.ErrorIs(t, err, want)
+}
+
+func TestNormalLoginKeepsLegacyWarningOnlySaveBehavior(t *testing.T) {
+	err := saveLoginTokens(&auth.TokenStorage{}, false, func(*auth.TokenStorage) error {
+		return errors.New("storage unavailable")
+	})
+
+	require.NoError(t, err)
+}

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -32,7 +32,6 @@ type ProfilesImportLocalInput struct {
 	BrowserProfile     string
 	ProfileName        string
 	Sites              []string
-	Count              int
 	Days               int
 	SkipConfirm        bool
 	Output             string
@@ -68,7 +67,18 @@ type sourcedPasswordManagerCandidate struct {
 	candidate passwordmanager.Candidate
 }
 
+type cookieImportSelection struct {
+	sites []string
+	all   bool
+}
+
+const managedAuthSiteLimit = 10
+
+const backOption = "← Back"
+
 var errRequestedProjectUnavailable = errors.New("requested Kernel project is not active or available")
+
+var errInteractiveBack = errors.New("go back to the previous browser-import menu")
 
 func dashboardProjectAuthRecovery(err error) bool {
 	return errors.Is(err, errRequestedProjectUnavailable) || dashboardProjectUnauthorized(err)
@@ -88,14 +98,8 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if runtime.GOOS != "darwin" {
 		return fmt.Errorf("local browser import currently supports macOS")
 	}
-	if in.Count < 5 || in.Count > 10 {
-		return fmt.Errorf("--count must be between 5 and 10")
-	}
 	if in.Days < 1 || in.Days > 90 {
 		return fmt.Errorf("--days must be between 1 and 90")
-	}
-	if len(in.Sites) > 10 {
-		return fmt.Errorf("select at most 10 sites")
 	}
 	if in.WaitTimeout <= 0 {
 		in.WaitTimeout = 30 * time.Minute
@@ -114,7 +118,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	humanOutput := in.Output != "json"
 	nonInteractive := in.SkipConfirm || !humanOutput
 	if humanOutput {
-		pterm.Info.Println("Looking for local Chrome profiles...")
+		pterm.Info.Println("Looking for local browser profiles...")
 	}
 	phaseStarted := time.Now()
 	profiles, err := localbrowser.DiscoverMacOSProfiles(home)
@@ -140,18 +144,6 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if targetName == "" || len(targetName) > 255 || profileIDNameCharacters.MatchString(targetName) || cuidLikeProfileName.MatchString(targetName) {
 		return fmt.Errorf("profile name must be 1-255 letters, numbers, dots, underscores, or hyphens and cannot be a cuid-like string")
 	}
-	recent := make([]localbrowser.Site, 0)
-	if len(in.Sites) == 0 {
-		phaseStarted = time.Now()
-		recent, err = localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 100)
-		timings["history"] = time.Since(phaseStarted)
-		if err != nil {
-			return err
-		}
-		if len(recent) == 0 {
-			return fmt.Errorf("no websites were visited in this profile during the last %d days", in.Days)
-		}
-	}
 	explicitSites := in.Sites
 	if len(explicitSites) > 0 {
 		explicitSites, err = normalizeSites(explicitSites)
@@ -159,33 +151,65 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 			return err
 		}
 	}
+	cookieSites := make([]localbrowser.Site, 0)
 	if len(explicitSites) == 0 {
 		if humanOutput {
-			pterm.Info.Printf("Counting cookies for %d recent websites...\n", len(recent))
+			pterm.Info.Println("Finding websites with importable cookies...")
 		}
 		phaseStarted = time.Now()
-		recent, err = localbrowser.CountCookiesForSites(ctx, profile, recent)
+		recent, historyErr := localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 10000)
+		timings["history"] = time.Since(phaseStarted)
+		if historyErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if humanOutput {
+				pterm.Warning.Println("Browser history could not be read; cookie websites will be sorted alphabetically")
+			}
+			recent = nil
+		}
+		phaseStarted = time.Now()
+		cookieSites, err = localbrowser.CookieSites(ctx, profile, recent)
 		timings["cookie_counts"] = time.Since(phaseStarted)
 		if err != nil {
 			return err
 		}
-		recent = offeredCookieSites(recent, in.Count)
-		if len(recent) == 0 {
-			return fmt.Errorf("the recent websites have no importable cookies")
+		if len(cookieSites) == 0 {
+			return fmt.Errorf("this browser profile has no importable cookies")
 		}
 	}
-	selected, err := c.chooseSites(recent, explicitSites, nonInteractive)
+	cookieSelection, err := c.chooseCookies(cookieSites, explicitSites, nonInteractive)
 	if err != nil {
 		return err
 	}
-	if len(selected) == 0 {
+	if len(cookieSelection.sites) == 0 {
 		return fmt.Errorf("select at least one website")
 	}
+	pendingLogins := pendingManagedAuth{}
+	if managedAuthImportRequested(in.PasswordManager, nonInteractive) {
+		phaseStarted = time.Now()
+		loginSites := rankedManagedAuthSites(cookieSites, cookieSelection.sites, managedAuthSiteLimit)
+		availableLoginSites := selectedSiteMetadata(cookieSites, cookieSelection.sites)
+		pendingLogins, err = c.chooseManagedAuthLogins(ctx, targetName, loginSites, availableLoginSites, in.PasswordManager, nonInteractive, humanOutput)
+		timings["password_manager_discovery"] = time.Since(phaseStarted)
+		if err != nil {
+			return err
+		}
+	}
 	if humanOutput {
-		pterm.Info.Printf("Reading cookies for %d selected websites...\n", len(selected))
+		pterm.Println()
+		if cookieSelection.all {
+			pterm.Info.Println("Reading all browser cookies...")
+		} else {
+			pterm.Info.Printf("Reading cookies for %d selected websites...\n", len(cookieSelection.sites))
+		}
+	}
+	exportSites := cookieSelection.sites
+	if cookieSelection.all {
+		exportSites = nil
 	}
 	phaseStarted = time.Now()
-	cookies, err := localbrowser.ExportCookies(ctx, profile, selected)
+	cookies, err := localbrowser.ExportCookies(ctx, profile, exportSites)
 	timings["cookies"] = time.Since(phaseStarted)
 	if err != nil {
 		return err
@@ -193,15 +217,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if len(cookies) == 0 {
 		return fmt.Errorf("the selected websites have no importable cookies")
 	}
-	pendingLogins := pendingManagedAuth{}
-	if managedAuthImportRequested(in.PasswordManager, nonInteractive) {
-		phaseStarted = time.Now()
-		pendingLogins, err = c.chooseManagedAuthLogins(ctx, targetName, selected, in.PasswordManager, nonInteractive, humanOutput)
-		timings["password_manager_discovery"] = time.Since(phaseStarted)
-		if err != nil {
-			return err
-		}
-	}
+	importedCookieSites := importedCookieSiteCount(cookies)
 
 	version := in.Version
 	if version == "" {
@@ -222,7 +238,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		return err
 	}
 	if humanOutput {
-		pterm.Info.Println("Creating Kernel profile...")
+		pterm.Info.Printf("Creating Kernel profile %q...\n", targetName)
 	}
 	phaseStarted = time.Now()
 	created, err := client.Create(ctx)
@@ -246,9 +262,6 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if err != nil {
 		return browserImportProgressError(created.ID, status.Phase, time.Since(phaseStarted), err)
 	}
-	if humanOutput {
-		pterm.Info.Println("Saving browser state to Kernel...")
-	}
 	waitCtx, cancelWait := context.WithTimeout(ctx, in.WaitTimeout)
 	defer cancelWait()
 	status, err = client.Wait(waitCtx, created.ID, 2*time.Second)
@@ -260,6 +273,9 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		return fmt.Errorf("browser import completed without a profile")
 	}
 	profileID := status.Applied.Profiles[0].ProfileID
+	if humanOutput {
+		pterm.Success.Printf("Imported %d cookies from %d websites\n", len(cookies), importedCookieSites)
+	}
 	connectionIDs := make([]string, 0)
 	approvedLogins := make([]passwordmanager.Record, 0)
 	if len(pendingLogins.providers) > 0 {
@@ -278,13 +294,24 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 			return fmt.Errorf("managed auth importer is unavailable")
 		}
 		if humanOutput {
-			pterm.Info.Printf("Creating %d Managed Auth connections...\n", len(approvedLogins))
+			pterm.Println()
+			pterm.Info.Printf("Setting up %d Managed Auth connections...\n", len(approvedLogins))
 		}
 		phaseStarted = time.Now()
 		connectionIDs, err = c.provisioner.Provision(ctx, targetName, approvedLogins)
 		timings["managed_auth"] = time.Since(phaseStarted)
 		if err != nil {
-			return fmt.Errorf("profile %s is ready, but Managed Auth setup stopped: %w", targetName, err)
+			if humanOutput {
+				for _, login := range approvedLogins[:min(len(connectionIDs), len(approvedLogins))] {
+					pterm.Success.Println(login.Domain)
+				}
+			}
+			return fmt.Errorf("profile %s is ready and %d Managed Auth connection%s completed, but setup stopped: %w; rerun the import to safely resume", targetName, len(connectionIDs), pluralSuffix(len(connectionIDs)), err)
+		}
+		if humanOutput {
+			for _, login := range approvedLogins {
+				pterm.Success.Println(login.Domain)
+			}
 		}
 	}
 	installedSkills := 0
@@ -298,18 +325,15 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		}
 	}
 	if in.Output == "json" {
-		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": selected, "cookies_imported": len(cookies), "managed_auth_connections": connectionIDs, "agent_skills_installed": installedSkills, "agent_skill_warning": skillWarning, "duration_ms": time.Since(startedAt).Milliseconds(), "timings_ms": durationMilliseconds(timings)}, "", "  ")
+		data, err := json.MarshalIndent(map[string]any{"profile_id": profileID, "profile_name": targetName, "sites": cookieSelection.sites, "cookies_imported": len(cookies), "managed_auth_connections": connectionIDs, "agent_skills_installed": installedSkills, "agent_skill_warning": skillWarning, "duration_ms": time.Since(startedAt).Milliseconds(), "timings_ms": durationMilliseconds(timings)}, "", "  ")
 		if err != nil {
 			return err
 		}
 		fmt.Println(string(data))
 		return nil
 	}
+	pterm.Println()
 	pterm.Success.Printf("%s is ready for agents\n", targetName)
-	pterm.Printf("Imported %d cookies from %d websites\n", len(cookies), len(selected))
-	if len(connectionIDs) > 0 {
-		pterm.Printf("Created %d Managed Auth connections with credentials and supported TOTP secrets\n", len(connectionIDs))
-	}
 	if skillWarning != "" {
 		pterm.Warning.Printf("Managed Auth is ready, but agent skill installation was skipped: %s\n", skillWarning)
 	}
@@ -370,7 +394,18 @@ func managedAuthImportRequested(requested string, nonInteractive bool) bool {
 	return !strings.EqualFold(strings.TrimSpace(requested), "none") && !(requested == "" && nonInteractive)
 }
 
-func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, profileName string, sites []string, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
+func importedCookieSiteCount(cookies []localbrowser.Cookie) int {
+	sites := make(map[string]struct{})
+	for _, cookie := range cookies {
+		domain, err := localbrowser.CanonicalSite(cookie.Domain)
+		if err == nil {
+			sites[domain] = struct{}{}
+		}
+	}
+	return len(sites)
+}
+
+func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, profileName string, sites []string, availableSites []localbrowser.Site, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
 	if strings.EqualFold(strings.TrimSpace(requested), "none") || (requested == "" && nonInteractive) {
 		return pendingManagedAuth{}, nil
 	}
@@ -420,6 +455,25 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 		return pendingManagedAuth{}, nil
 	}
 	chosenProviders = deduplicatePasswordManagers(chosenProviders)
+	var (
+		capacityHint    managedAuthCapacity
+		capacityHintErr error
+		capacityLoaded  bool
+	)
+	if !nonInteractive && c.managedAuthCapacity != nil {
+		capacityHint, capacityHintErr = c.managedAuthCapacity(ctx)
+		capacityLoaded = capacityHintErr == nil
+	}
+	sites, err := c.chooseManagedAuthSites(sites, availableSites, nonInteractive, capacityHint, capacityLoaded && capacityHintErr == nil)
+	if err != nil {
+		return pendingManagedAuth{}, err
+	}
+	if len(sites) == 0 {
+		return pendingManagedAuth{}, nil
+	}
+	if humanOutput {
+		pterm.Println()
+	}
 	allCandidates := make([]sourcedPasswordManagerCandidate, 0)
 	for _, provider := range chosenProviders {
 		if authorizer, ok := provider.(passwordmanager.InteractiveAuthorizer); ok {
@@ -437,13 +491,7 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 				if nonInteractive {
 					return pendingManagedAuth{}, fmt.Errorf("Bitwarden is locked; unlock it with `export BW_SESSION=$(bw unlock --raw)`, then retry")
 				}
-				approved, err := c.prompter.ConfirmDefault("unlock Bitwarden", "Bitwarden is locked. Unlock it locally to find matching logins?", true)
-				if err != nil {
-					return pendingManagedAuth{}, err
-				}
-				if !approved {
-					continue
-				}
+				pterm.Println("Enter your Bitwarden master password to find matching logins:")
 				if err := authorizer.Authorize(ctx); err != nil {
 					if humanOutput {
 						pterm.Warning.Printf("Skipping %s: %v\n", provider.Name(), err)
@@ -452,11 +500,12 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 				}
 				if humanOutput {
 					pterm.Success.Println("Bitwarden unlocked for this import")
+					pterm.Println()
 				}
 			}
 		}
 		if humanOutput {
-			pterm.Info.Printf("Find matching %s logins...\n", provider.Name())
+			pterm.Info.Printf("Finding matching %s logins...\n", provider.Name())
 		}
 		candidates, err := discoverProviderCandidates(ctx, provider, sites, nonInteractive, humanOutput)
 		if err != nil {
@@ -508,7 +557,10 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 			return pendingManagedAuth{}, fmt.Errorf("managed auth capacity is unavailable")
 		}
 	} else {
-		capacity, capacityErr := c.managedAuthCapacity(ctx)
+		capacity, capacityErr := capacityHint, capacityHintErr
+		if !capacityLoaded {
+			capacity, capacityErr = c.managedAuthCapacity(ctx)
+		}
 		if capacityErr != nil {
 			capacityLookupErr = capacityErr
 			if hasNew && requested != "" && nonInteractive {
@@ -551,43 +603,24 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 	for index, site := range sites {
 		siteRank[site] = index
 	}
+	providerRank := make(map[string]int, len(chosenProviders))
+	for index, provider := range chosenProviders {
+		providerRank[provider.Name()] = index
+	}
 	sort.SliceStable(allCandidates, func(i, j int) bool {
 		left := allCandidates[i]
 		right := allCandidates[j]
 		if siteRank[left.candidate.Domain] != siteRank[right.candidate.Domain] {
 			return siteRank[left.candidate.Domain] < siteRank[right.candidate.Domain]
 		}
-		if left.provider.Name() != right.provider.Name() {
-			return left.provider.Name() < right.provider.Name()
+		if providerRank[left.provider.Name()] != providerRank[right.provider.Name()] {
+			return providerRank[left.provider.Name()] < providerRank[right.provider.Name()]
 		}
 		return left.candidate.Name < right.candidate.Name
 	})
-	labels := make([]string, 0, len(allCandidates))
-	byLabel := make(map[string]sourcedPasswordManagerCandidate, len(allCandidates))
-	defaultLabels := make([]string, 0, len(sites))
-	remainingDefaults := availableConnections
 	domainCounts := make(map[string]int, len(sites))
 	for _, sourced := range allCandidates {
 		domainCounts[sourced.candidate.Domain]++
-	}
-	for index, sourced := range allCandidates {
-		candidate := sourced.candidate
-		idSuffix := candidate.ID
-		if len(idSuffix) > 6 {
-			idSuffix = idSuffix[len(idSuffix)-6:]
-		}
-		label := loginCandidateLabel(index, sourced.provider.Name(), candidate, idSuffix)
-		labels = append(labels, label)
-		byLabel[label] = sourced
-		if domainCounts[candidate.Domain] == 1 {
-			if !existing[candidateKey(candidate)] && remainingDefaults == 0 {
-				continue
-			}
-			defaultLabels = append(defaultLabels, label)
-			if !existing[candidateKey(candidate)] {
-				remainingDefaults--
-			}
-		}
 	}
 	if requested != "" && nonInteractive {
 		requiredNew := 0
@@ -608,35 +641,31 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 			}
 		}
 	}
-	chosenLabels := defaultLabels
-	if !nonInteractive {
-		for {
-			prompt := "Choose logins for Managed Auth (existing connections do not use a new slot)"
-			selected, promptErr := c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", prompt, labels, chosenLabels)
-			if promptErr != nil {
-				return pendingManagedAuth{}, promptErr
-			}
-			if duplicateDomain := duplicateSelectedDomain(selected, byLabel); duplicateDomain != "" {
-				pterm.Warning.Printf("Choose only one login for %s; your selections are preserved\n", duplicateDomain)
-				chosenLabels = selected
+	approvedCandidates := make([]sourcedPasswordManagerCandidate, 0, len(sites))
+	if nonInteractive {
+		remaining := availableConnections
+		for _, sourced := range allCandidates {
+			candidate := sourced.candidate
+			if domainCounts[candidate.Domain] != 1 {
 				continue
 			}
-			if excess := selectedNewConnectionCount(selected, byLabel, existing) - availableConnections; excess > 0 {
-				pterm.Warning.Printf("Your selection needs %d more Managed Auth connection slot%s; your selections are preserved\n", excess, pluralSuffix(excess))
-				chosenLabels = selected
-				continue
+			if !existing[candidateKey(candidate)] {
+				if remaining == 0 {
+					continue
+				}
+				remaining--
 			}
-			chosenLabels = selected
-			break
+			approvedCandidates = append(approvedCandidates, sourced)
+		}
+	} else {
+		approvedCandidates, err = c.chooseManagedAuthAccountsByWebsite(sites, allCandidates, existing, availableConnections)
+		if err != nil {
+			return pendingManagedAuth{}, err
 		}
 	}
-	if selectedNewConnectionCount(chosenLabels, byLabel, existing) > availableConnections {
-		return pendingManagedAuth{}, fmt.Errorf("select at most %d new Managed Auth login%s", availableConnections, pluralSuffix(availableConnections))
-	}
 	approvedByProvider := make(map[string][]passwordmanager.Candidate, len(chosenProviders))
-	selectedDomains := make(map[string]struct{}, len(chosenLabels))
-	for _, label := range chosenLabels {
-		sourced := byLabel[label]
+	selectedDomains := make(map[string]struct{}, len(approvedCandidates))
+	for _, sourced := range approvedCandidates {
 		candidate := sourced.candidate
 		if _, exists := selectedDomains[candidate.Domain]; exists {
 			return pendingManagedAuth{}, fmt.Errorf("select at most one login for %s", candidate.Domain)
@@ -653,22 +682,265 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, pro
 	return pending, nil
 }
 
+func (c ProfilesImportLocalCmd) chooseManagedAuthAccountsByWebsite(sites []string, candidates []sourcedPasswordManagerCandidate, existing map[string]bool, availableConnections int) ([]sourcedPasswordManagerCandidate, error) {
+	byDomain := make(map[string][]sourcedPasswordManagerCandidate, len(sites))
+	for _, candidate := range candidates {
+		byDomain[candidate.candidate.Domain] = append(byDomain[candidate.candidate.Domain], candidate)
+	}
+
+	pterm.Println()
+	pterm.Println("Choose one login per website for Managed Auth:")
+	pterm.Println()
+	domains := make([]string, 0, len(sites))
+	for _, domain := range sites {
+		if len(byDomain[domain]) > 0 {
+			domains = append(domains, domain)
+		}
+	}
+	choices := make(map[string]sourcedPasswordManagerCandidate, len(domains))
+	for domainIndex := 0; domainIndex < len(domains); {
+		domain := domains[domainIndex]
+		domainCandidates := byDomain[domain]
+		if len(domainCandidates) == 1 {
+			chosen := domainCandidates[0]
+			delete(choices, domain)
+			if !existing[candidateKey(chosen.candidate)] && managedAuthNewChoiceCount(choices, existing) >= availableConnections {
+				pterm.Warning.Printf("Skipping %s: no Managed Auth connection slots remain\n", domain)
+				domainIndex++
+				continue
+			}
+			choices[domain] = chosen
+			pterm.Info.Printf("Will use %s — %s %s\n", domain, passwordManagerAbbreviation(chosen.provider.Name()), managedAuthCandidateIdentity(chosen.candidate))
+			domainIndex++
+			continue
+		}
+		labels := make([]string, 0, len(domainCandidates))
+		byLabel := make(map[string]sourcedPasswordManagerCandidate, len(domainCandidates))
+		existingLabels := make([]string, 0, len(domainCandidates))
+		labels = groupedLoginLabels(domainCandidates)
+		for index, sourced := range domainCandidates {
+			label := labels[index]
+			byLabel[label] = sourced
+			if existing[candidateKey(sourced.candidate)] {
+				existingLabels = append(existingLabels, label)
+			}
+		}
+		options := append([]string{}, labels...)
+		options = append(options, "Skip this website")
+		if previousAmbiguousDomainIndex(domains, byDomain, domainIndex) >= 0 {
+			options = append(options, "← Previous website")
+		}
+		defaultOption := labels[0]
+		if previous, ok := choices[domain]; ok {
+			for label, candidate := range byLabel {
+				if candidateKey(candidate.candidate) == candidateKey(previous.candidate) {
+					defaultOption = label
+					break
+				}
+			}
+		} else if len(existingLabels) == 1 {
+			defaultOption = existingLabels[0]
+		} else if managedAuthNewChoiceCount(choices, existing) >= availableConnections {
+			defaultOption = "Skip this website"
+		}
+		selected, err := c.prompter.SelectDefault("login for "+domain, "use arrow keys and press Enter", domain+" — ↑/↓ move, Enter chooses", options, defaultOption)
+		if err != nil {
+			return nil, err
+		}
+		switch selected {
+		case "← Previous website":
+			previousIndex := previousAmbiguousDomainIndex(domains, byDomain, domainIndex)
+			if previousIndex < 0 {
+				continue
+			}
+			for index := previousIndex; index < len(domains); index++ {
+				delete(choices, domains[index])
+			}
+			domainIndex = previousIndex
+			continue
+		case "Skip this website":
+			delete(choices, domain)
+			domainIndex++
+			continue
+		}
+		chosen := byLabel[selected]
+		previous, hadPrevious := choices[domain]
+		delete(choices, domain)
+		if !existing[candidateKey(chosen.candidate)] && managedAuthNewChoiceCount(choices, existing) >= availableConnections {
+			if hadPrevious {
+				choices[domain] = previous
+			}
+			pterm.Warning.Printf("No Managed Auth connection slots remain; choose an existing connection or skip %s\n", domain)
+			continue
+		}
+		choices[domain] = chosen
+		domainIndex++
+		pterm.Println()
+	}
+	approved := make([]sourcedPasswordManagerCandidate, 0, len(choices))
+	for _, domain := range domains {
+		if chosen, ok := choices[domain]; ok {
+			approved = append(approved, chosen)
+		}
+	}
+	return approved, nil
+}
+
+func previousAmbiguousDomainIndex(domains []string, candidates map[string][]sourcedPasswordManagerCandidate, current int) int {
+	for index := current - 1; index >= 0; index-- {
+		if len(candidates[domains[index]]) > 1 {
+			return index
+		}
+	}
+	return -1
+}
+
+func managedAuthNewChoiceCount(choices map[string]sourcedPasswordManagerCandidate, existing map[string]bool) int {
+	count := 0
+	for _, choice := range choices {
+		if !existing[candidateKey(choice.candidate)] {
+			count++
+		}
+	}
+	return count
+}
+
+func (c ProfilesImportLocalCmd) chooseManagedAuthSites(sites []string, availableSites []localbrowser.Site, nonInteractive bool, capacity managedAuthCapacity, capacityKnown bool) ([]string, error) {
+	if nonInteractive || len(sites) == 0 {
+		return sites, nil
+	}
+	prompt, defaultDomains := managedAuthSitePrompt(sites, capacity, capacityKnown)
+	recommendedSet := make(map[string]struct{}, len(sites))
+	for _, domain := range sites {
+		recommendedSet[domain] = struct{}{}
+	}
+	selected := append([]string(nil), defaultDomains...)
+	const findAnotherOption = "+ Find another website"
+	for {
+		labels, byLabel := managedAuthRecommendationOptions(sites, availableSites)
+		for _, domain := range selected {
+			if _, recommended := recommendedSet[domain]; recommended {
+				continue
+			}
+			label := managedAuthSiteOption(len(labels), domain, siteMetadata(availableSites, domain))
+			labels = append(labels, label)
+			byLabel[label] = domain
+		}
+		labels = append(labels, findAnotherOption)
+		currentSet := make(map[string]struct{}, len(selected))
+		for _, domain := range selected {
+			currentSet[domain] = struct{}{}
+		}
+		selectedDefaults := make([]string, 0, len(selected))
+		for _, label := range labels {
+			if _, checked := currentSet[byLabel[label]]; checked {
+				selectedDefaults = append(selectedDefaults, label)
+			}
+		}
+		sectionPrompt := prompt + "\nSpace toggles websites · check + Find another website to search · Enter continues"
+		selectedLabels, err := c.prompter.MultiSelect("Managed Auth websites", "pass --yes to use the suggested websites", sectionPrompt, labels, selectedDefaults)
+		if err != nil {
+			return nil, err
+		}
+		result := make([]string, 0, len(selectedLabels))
+		findAnother := false
+		for _, label := range selectedLabels {
+			if label == findAnotherOption {
+				findAnother = true
+				continue
+			}
+			result = append(result, byLabel[label])
+		}
+		selected = result
+		if !findAnother {
+			return selected, nil
+		}
+		options, domains := managedAuthSearchOptions(availableSites, selected)
+		if len(options) == 1 {
+			pterm.Info.Println("Every browser website is already selected")
+			continue
+		}
+		chosen, err := c.prompter.Select("Managed Auth website", "select a website", "Find another website — type to search, Enter adds, Back returns", options)
+		if err != nil {
+			return nil, err
+		}
+		if chosen != backOption && !containsString(selected, domains[chosen]) {
+			selected = append(selected, domains[chosen])
+		}
+	}
+}
+
+func managedAuthSitePrompt(sites []string, capacity managedAuthCapacity, capacityKnown bool) (string, []string) {
+	defaults := sites
+	prompt := "Choose recent websites to find Managed Auth logins"
+	if capacityKnown && !capacity.unlimited {
+		prompt = fmt.Sprintf("Choose recent websites to find Managed Auth logins (%d new connection slot%s available)", capacity.remaining, pluralSuffix(capacity.remaining))
+	}
+	return prompt, defaults
+}
+
+func managedAuthRecommendationOptions(sites []string, available []localbrowser.Site) ([]string, map[string]string) {
+	metadata := make(map[string]localbrowser.Site, len(available))
+	for _, site := range available {
+		metadata[site.Domain] = site
+	}
+	options := make([]string, 0, len(sites))
+	byOption := make(map[string]string, len(sites))
+	for index, domain := range sites {
+		label := managedAuthSiteOption(index, domain, metadata[domain])
+		options = append(options, label)
+		byOption[label] = domain
+	}
+	return options, byOption
+}
+
+func managedAuthSiteOption(index int, domain string, site localbrowser.Site) string {
+	label := fmt.Sprintf("%d  %s", index+1, domain)
+	if site.Visits > 0 {
+		label += fmt.Sprintf("  %s visits", boundedCount(site.Visits))
+	}
+	return label
+}
+
+func siteMetadata(sites []localbrowser.Site, domain string) localbrowser.Site {
+	for _, site := range sites {
+		if site.Domain == domain {
+			return site
+		}
+	}
+	return localbrowser.Site{Domain: domain}
+}
+
+func managedAuthSearchOptions(available []localbrowser.Site, selected []string) ([]string, map[string]string) {
+	options := make([]string, 0, len(available)+1)
+	options = append(options, backOption)
+	byOption := make(map[string]string, len(available))
+	for index, site := range available {
+		if containsString(selected, site.Domain) {
+			continue
+		}
+		label := fmt.Sprintf("%d  %-28s %s visits", index+1, compactField(site.Domain, 28), boundedCount(site.Visits))
+		label = ansi.Truncate(label, 64, "…")
+		options = append(options, label)
+		byOption[label] = site.Domain
+	}
+	return options, byOption
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func managedAuthDiscoveryFailure(requested, action string, err error) error {
 	if requested == "" {
 		return nil
 	}
 	return fmt.Errorf("%s: %w", action, err)
-}
-
-func selectedNewConnectionCount(labels []string, byLabel map[string]sourcedPasswordManagerCandidate, existing map[string]bool) int {
-	count := 0
-	for _, label := range labels {
-		candidate := byLabel[label].candidate
-		if !existing[candidateKey(candidate)] {
-			count++
-		}
-	}
-	return count
 }
 
 func pluralSuffix(count int) string {
@@ -690,18 +962,6 @@ func discoverProviderCandidates(ctx context.Context, provider passwordmanager.Pr
 		pterm.Warning.Printf("Skipping %s: %v\n", provider.Name(), err)
 	}
 	return nil, nil
-}
-
-func duplicateSelectedDomain(selected []string, candidates map[string]sourcedPasswordManagerCandidate) string {
-	seen := make(map[string]struct{}, len(selected))
-	for _, label := range selected {
-		domain := candidates[label].candidate.Domain
-		if _, exists := seen[domain]; exists {
-			return domain
-		}
-		seen[domain] = struct{}{}
-	}
-	return ""
 }
 
 func findPasswordManager(providers []passwordmanager.Provider, requested string) passwordmanager.Provider {
@@ -838,28 +1098,137 @@ func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requeste
 	if skipPrompt {
 		return defaults, nil
 	}
-	labels := make([]string, 0, len(recent))
-	byLabel := make(map[string]string, len(recent))
-	defaultLabels := make([]string, 0, len(recent))
-	for _, site := range recent {
-		label := cookieSiteLabel(site)
-		labels = append(labels, label)
-		byLabel[label] = site.Domain
-		defaultLabels = append(defaultLabels, label)
+	selected := append([]localbrowser.Site(nil), recent...)
+	for {
+		options, byOption := cookieRemovalOptions(selected)
+		chosen, err := c.prompter.Select("websites", "pass --sites or --yes", "Remove a website, or continue", options)
+		if err != nil {
+			return nil, err
+		}
+		if chosen == backOption {
+			return nil, errInteractiveBack
+		}
+		removeIndex, remove := byOption[chosen]
+		if !remove {
+			break
+		}
+		selected = append(selected[:removeIndex], selected[removeIndex+1:]...)
 	}
-	chosen, err := c.prompter.MultiSelect("websites", "pass --sites or --yes", "Choose websites whose cookies should be imported", labels, defaultLabels)
-	if err != nil {
-		return nil, err
-	}
-	result := make([]string, 0, len(chosen))
-	for _, label := range chosen {
-		result = append(result, byLabel[label])
+	result := make([]string, 0, len(selected))
+	for _, site := range selected {
+		result = append(result, site.Domain)
 	}
 	return result, nil
 }
 
-func cookieSiteLabel(site localbrowser.Site) string {
-	label := fmt.Sprintf("%-28s %s visits · %s cookies", compactField(site.Domain, 28), boundedCount(site.Visits), boundedCount(site.CookieCount))
+func cookieRemovalOptions(sites []localbrowser.Site) ([]string, map[string]int) {
+	options := make([]string, 0, len(sites)+2)
+	options = append(options, fmt.Sprintf("Done — import %d website%s", len(sites), pluralSuffix(len(sites))))
+	options = append(options, backOption)
+	byOption := make(map[string]int, len(sites))
+	for index, site := range sites {
+		label := cookieSiteLabel(index, site)
+		options = append(options, label)
+		byOption[label] = index
+	}
+	return options, byOption
+}
+
+func (c ProfilesImportLocalCmd) chooseCookies(sites []localbrowser.Site, requested []string, skipPrompt bool) (cookieImportSelection, error) {
+	if len(requested) > 0 {
+		normalized, err := normalizeSites(requested)
+		return cookieImportSelection{sites: normalized}, err
+	}
+	allSites := make([]string, 0, len(sites))
+	for _, site := range sites {
+		allSites = append(allSites, site.Domain)
+	}
+	if skipPrompt {
+		return cookieImportSelection{sites: allSites, all: true}, nil
+	}
+	options := cookieImportOptions(sites)
+	for {
+		choice, err := c.prompter.Select("cookies", "pass --sites or --yes", "What should Kernel import?", options)
+		if err != nil {
+			return cookieImportSelection{}, err
+		}
+		if choice == options[0] {
+			return cookieImportSelection{sites: allSites, all: true}, nil
+		}
+		selected, err := c.chooseSites(sites, nil, false)
+		if errors.Is(err, errInteractiveBack) {
+			continue
+		}
+		return cookieImportSelection{sites: selected}, err
+	}
+}
+
+func cookieImportOptions(sites []localbrowser.Site) []string {
+	total := 0
+	for _, site := range sites {
+		total += site.CookieCount
+	}
+	all := fmt.Sprintf(
+		"All cookies (recommended) — %d cookie%s across %d website%s",
+		total,
+		pluralSuffix(total),
+		len(sites),
+		pluralSuffix(len(sites)),
+	)
+	return []string{all, "Choose websites"}
+}
+
+func rankedManagedAuthSites(ranked []localbrowser.Site, selected []string, limit int) []string {
+	if len(ranked) == 0 {
+		return append([]string(nil), selected[:min(limit, len(selected))]...)
+	}
+	selectedSet := make(map[string]struct{}, len(selected))
+	for _, site := range selected {
+		selectedSet[site] = struct{}{}
+	}
+	result := make([]string, 0, min(limit, len(selected)))
+	for _, site := range ranked {
+		if site.Visits == 0 {
+			continue
+		}
+		if _, ok := selectedSet[site.Domain]; !ok {
+			continue
+		}
+		result = append(result, site.Domain)
+		if len(result) == limit {
+			break
+		}
+	}
+	if len(result) == 0 {
+		return append([]string(nil), selected[:min(limit, len(selected))]...)
+	}
+	return result
+}
+
+func selectedSiteMetadata(ranked []localbrowser.Site, selected []string) []localbrowser.Site {
+	selectedSet := make(map[string]struct{}, len(selected))
+	for _, domain := range selected {
+		selectedSet[domain] = struct{}{}
+	}
+	result := make([]localbrowser.Site, 0, len(selected))
+	seen := make(map[string]struct{}, len(selected))
+	for _, site := range ranked {
+		if _, ok := selectedSet[site.Domain]; !ok {
+			continue
+		}
+		result = append(result, site)
+		seen[site.Domain] = struct{}{}
+	}
+	for _, domain := range selected {
+		if _, ok := seen[domain]; !ok {
+			result = append(result, localbrowser.Site{Domain: domain})
+		}
+	}
+	return result
+}
+
+func cookieSiteLabel(index int, site localbrowser.Site) string {
+	label := fmt.Sprintf("%d  %-24s %s visits · %s cookies", index+1, compactField(site.Domain, 24), boundedCount(site.Visits), boundedCount(site.CookieCount))
 	return ansi.Truncate(label, 64, "…")
 }
 
@@ -869,24 +1238,6 @@ func boundedCount(value int) string {
 		return text
 	}
 	return fmt.Sprintf("%.2e", float64(value))
-}
-
-func sitesWithCookies(sites []localbrowser.Site) []localbrowser.Site {
-	result := make([]localbrowser.Site, 0, len(sites))
-	for _, site := range sites {
-		if site.CookieCount > 0 {
-			result = append(result, site)
-		}
-	}
-	return result
-}
-
-func offeredCookieSites(sites []localbrowser.Site, count int) []localbrowser.Site {
-	result := sitesWithCookies(sites)
-	if len(result) > count {
-		return result[:count]
-	}
-	return result
 }
 
 func normalizeSites(values []string) ([]string, error) {
@@ -938,15 +1289,49 @@ func compactField(value string, limit int) string {
 	return ansi.Truncate(strings.Join(strings.Fields(value), " "), limit, "…")
 }
 
-func loginCandidateLabel(index int, provider string, candidate passwordmanager.Candidate, idSuffix string) string {
+func groupedLoginCandidateLabel(provider string, candidate passwordmanager.Candidate) string {
+	idSuffix := candidate.ID
+	if len(idSuffix) > 6 {
+		idSuffix = idSuffix[len(idSuffix)-6:]
+	}
+	return groupedLoginCandidateLabelWithID(provider, candidate, idSuffix)
+}
+
+func managedAuthCandidateIdentity(candidate passwordmanager.Candidate) string {
+	if candidate.Username != "" {
+		return compactField(candidate.Username, 40)
+	}
+	return compactField(candidate.Name, 40)
+}
+
+func groupedLoginLabels(candidates []sourcedPasswordManagerCandidate) []string {
+	baseCounts := make(map[string]int, len(candidates))
+	for _, sourced := range candidates {
+		baseCounts[groupedLoginCandidateLabel(sourced.provider.Name(), sourced.candidate)]++
+	}
+	labels := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for index, sourced := range candidates {
+		base := groupedLoginCandidateLabel(sourced.provider.Name(), sourced.candidate)
+		label := base
+		if baseCounts[base] > 1 {
+			label = groupedLoginCandidateLabelWithID(sourced.provider.Name(), sourced.candidate, sourced.candidate.ID)
+			if _, collision := seen[label]; collision {
+				label += fmt.Sprintf(" · #%d", index+1)
+			}
+		}
+		labels = append(labels, label)
+		seen[label] = struct{}{}
+	}
+	return labels
+}
+
+func groupedLoginCandidateLabelWithID(provider string, candidate passwordmanager.Candidate, id string) string {
 	identity := candidate.Username
 	if identity == "" {
 		identity = "no username"
 	}
-	indexLabel := fmt.Sprintf("%d", index+1)
-	indexWidth := max(2, ansi.StringWidth(indexLabel))
-	nameWidth := max(8, 16-(indexWidth-2))
-	return fmt.Sprintf("%*s  %s  %s  %s  %s · %s", indexWidth, indexLabel, passwordManagerAbbreviation(provider), compactField(candidate.Domain, 15), compactField(identity, 18), compactField(candidate.Name, nameWidth), idSuffix)
+	return fmt.Sprintf("%s  %-24s  %s · %s", passwordManagerAbbreviation(provider), compactField(identity, 24), compactField(candidate.Name, 22), compactField(id, 12))
 }
 
 func passwordManagerAbbreviation(provider string) string {
@@ -1020,8 +1405,8 @@ var cuidLikeProfileName = regexp.MustCompile(`^[a-z0-9]{24}$`)
 
 var profilesImportLocalCmd = &cobra.Command{
 	Use:   "import-local",
-	Short: "Import recent websites from a local browser",
-	Long:  "Import selected cookies from a local Google Chrome or Helium profile on macOS into a Kernel browser profile.",
+	Short: "Import cookies from a local browser",
+	Long:  "Import all cookies or selected websites from a local Google Chrome or Helium profile on macOS into a Kernel browser profile.",
 	Args:  cobra.NoArgs,
 	RunE:  runProfilesImportLocal,
 }
@@ -1038,11 +1423,10 @@ func init() {
 	profilesCmd.AddCommand(profilesImportStatusCmd)
 	profilesImportLocalCmd.Flags().String("browser-profile", "", "Local browser profile ID or name")
 	profilesImportLocalCmd.Flags().String("profile-name", "", "Kernel profile name")
-	profilesImportLocalCmd.Flags().StringSlice("sites", nil, "Website domains to import (up to 10)")
-	profilesImportLocalCmd.Flags().Int("count", 10, "Number of recent websites to offer (5-10); all are selected by default")
+	profilesImportLocalCmd.Flags().StringSlice("sites", nil, "Import cookies only for these website domains")
 	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
 	profilesImportLocalCmd.Flags().Duration("wait-timeout", 30*time.Minute, "Maximum time to wait for the import to complete")
-	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
+	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Import all cookies and use unambiguous defaults without prompting")
 	profilesImportLocalCmd.Flags().String("password-manager", "", "Password managers to search: bitwarden, 1password, both comma-separated, all, or none")
 	profilesImportLocalCmd.Flags().Bool("install-agent-skills", false, "Install the Kernel Managed Auth skill into detected agent directories")
 	addJSONOutputFlag(profilesImportLocalCmd)
@@ -1053,7 +1437,6 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	browserProfile, _ := cmd.Flags().GetString("browser-profile")
 	profileName, _ := cmd.Flags().GetString("profile-name")
 	sites, _ := cmd.Flags().GetStringSlice("sites")
-	count, _ := cmd.Flags().GetInt("count")
 	days, _ := cmd.Flags().GetInt("days")
 	waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
 	skipConfirm, _ := cmd.Flags().GetBool("yes")
@@ -1062,7 +1445,7 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	project, _ := cmd.Flags().GetString("project")
 	return runProfilesImportLocalWithInput(cmd, ProfilesImportLocalInput{
-		BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days,
+		BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Days: days,
 		SkipConfirm: skipConfirm, Output: output, ProjectID: resolveProjectSelection(project), Version: metadata.Version,
 		WaitTimeout: waitTimeout, PasswordManager: passwordManager, InstallAgentSkills: installAgentSkills,
 	})

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -46,11 +46,12 @@ type ProfilesImportLocalInput struct {
 }
 
 type ProfilesImportLocalCmd struct {
-	prompter    interactive.Prompter
-	homeDir     func() (string, error)
-	now         func() time.Time
-	providers   func() []passwordmanager.Provider
-	provisioner managedAuthProvisioner
+	prompter            interactive.Prompter
+	homeDir             func() (string, error)
+	now                 func() time.Time
+	providers           func() []passwordmanager.Provider
+	provisioner         managedAuthProvisioner
+	managedAuthCapacity func(context.Context) (managedAuthCapacity, error)
 }
 
 type pendingManagedAuth struct {
@@ -142,7 +143,7 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	recent := make([]localbrowser.Site, 0)
 	if len(in.Sites) == 0 {
 		phaseStarted = time.Now()
-		recent, err = localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 10)
+		recent, err = localbrowser.RecentSites(ctx, profile, c.now().AddDate(0, 0, -in.Days), 100)
 		timings["history"] = time.Since(phaseStarted)
 		if err != nil {
 			return err
@@ -168,12 +169,12 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 		if err != nil {
 			return err
 		}
-		recent = sitesWithCookies(recent)
+		recent = offeredCookieSites(recent, in.Count)
 		if len(recent) == 0 {
 			return fmt.Errorf("the recent websites have no importable cookies")
 		}
 	}
-	selected, err := c.chooseSites(recent, explicitSites, in.Count, nonInteractive)
+	selected, err := c.chooseSites(recent, explicitSites, nonInteractive)
 	if err != nil {
 		return err
 	}
@@ -192,11 +193,14 @@ func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalI
 	if len(cookies) == 0 {
 		return fmt.Errorf("the selected websites have no importable cookies")
 	}
-	phaseStarted = time.Now()
-	pendingLogins, err := c.chooseManagedAuthLogins(ctx, selected, in.PasswordManager, nonInteractive, humanOutput)
-	timings["password_manager_discovery"] = time.Since(phaseStarted)
-	if err != nil {
-		return err
+	pendingLogins := pendingManagedAuth{}
+	if managedAuthImportRequested(in.PasswordManager, nonInteractive) {
+		phaseStarted = time.Now()
+		pendingLogins, err = c.chooseManagedAuthLogins(ctx, targetName, selected, in.PasswordManager, nonInteractive, humanOutput)
+		timings["password_manager_discovery"] = time.Since(phaseStarted)
+		if err != nil {
+			return err
+		}
 	}
 
 	version := in.Version
@@ -362,7 +366,11 @@ func (c ProfilesImportLocalCmd) offerAgentSkills(home string, installRequested, 
 	return len(selected), nil
 }
 
-func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sites []string, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
+func managedAuthImportRequested(requested string, nonInteractive bool) bool {
+	return !strings.EqualFold(strings.TrimSpace(requested), "none") && !(requested == "" && nonInteractive)
+}
+
+func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, profileName string, sites []string, requested string, nonInteractive, humanOutput bool) (pendingManagedAuth, error) {
 	if strings.EqualFold(strings.TrimSpace(requested), "none") || (requested == "" && nonInteractive) {
 		return pendingManagedAuth{}, nil
 	}
@@ -464,9 +472,100 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 	if len(allCandidates) == 0 {
 		return pendingManagedAuth{}, nil
 	}
+	if c.provisioner == nil {
+		return pendingManagedAuth{}, fmt.Errorf("managed auth importer is unavailable")
+	}
+	candidates := make([]passwordmanager.Candidate, 0, len(allCandidates))
+	for _, sourced := range allCandidates {
+		candidates = append(candidates, sourced.candidate)
+	}
+	existing, err := c.provisioner.Existing(ctx, profileName, candidates)
+	if err != nil {
+		if failure := managedAuthDiscoveryFailure(requested, "check existing Managed Auth connections", err); failure != nil {
+			return pendingManagedAuth{}, failure
+		}
+		if humanOutput {
+			pterm.Warning.Printf("Could not check existing Managed Auth connections; continuing with cookies: %v\n", err)
+		}
+		return pendingManagedAuth{}, nil
+	}
+	hasExisting := false
+	hasNew := false
+	for _, candidate := range candidates {
+		if existing[candidateKey(candidate)] {
+			hasExisting = true
+		} else {
+			hasNew = true
+		}
+	}
+	availableConnections := 0
+	capacityKnown := !hasNew
+	var capacityLookupErr error
+	if !hasNew {
+		// Existing imports refresh their credential and do not consume quota.
+	} else if c.managedAuthCapacity == nil {
+		if !hasExisting {
+			return pendingManagedAuth{}, fmt.Errorf("managed auth capacity is unavailable")
+		}
+	} else {
+		capacity, capacityErr := c.managedAuthCapacity(ctx)
+		if capacityErr != nil {
+			capacityLookupErr = capacityErr
+			if hasNew && requested != "" && nonInteractive {
+				return pendingManagedAuth{}, fmt.Errorf("check Managed Auth capacity: %w", capacityErr)
+			}
+			if humanOutput {
+				pterm.Warning.Printf("Could not check capacity; only existing Managed Auth connections can be refreshed: %v\n", capacityErr)
+			}
+		} else {
+			capacityKnown = true
+			availableConnections = capacity.remaining
+			if capacity.unlimited {
+				availableConnections = len(sites)
+			} else if humanOutput {
+				pterm.Info.Printf("Your organization has %d Managed Auth connection slot%s available\n", availableConnections, pluralSuffix(availableConnections))
+			}
+		}
+	}
+	if hasNew && !capacityKnown {
+		if requested != "" && !hasExisting {
+			return pendingManagedAuth{}, fmt.Errorf("check Managed Auth capacity: %w", capacityLookupErr)
+		}
+		if !hasExisting {
+			return pendingManagedAuth{}, nil
+		}
+	}
+	if availableConnections == 0 && hasNew && requested != "" && nonInteractive {
+		return pendingManagedAuth{}, fmt.Errorf("your organization has no Managed Auth connection slots available for new logins; delete a connection or upgrade your plan, then retry")
+	}
+	if capacityKnown && availableConnections == 0 && !hasExisting {
+		if requested != "" {
+			return pendingManagedAuth{}, fmt.Errorf("your organization has no Managed Auth connection slots available; delete a connection or upgrade your plan, then retry")
+		}
+		if humanOutput {
+			pterm.Info.Println("Managed Auth is at your organization's connection limit; continuing with cookies")
+		}
+		return pendingManagedAuth{}, nil
+	}
+	siteRank := make(map[string]int, len(sites))
+	for index, site := range sites {
+		siteRank[site] = index
+	}
+	sort.SliceStable(allCandidates, func(i, j int) bool {
+		left := allCandidates[i]
+		right := allCandidates[j]
+		if siteRank[left.candidate.Domain] != siteRank[right.candidate.Domain] {
+			return siteRank[left.candidate.Domain] < siteRank[right.candidate.Domain]
+		}
+		if left.provider.Name() != right.provider.Name() {
+			return left.provider.Name() < right.provider.Name()
+		}
+		return left.candidate.Name < right.candidate.Name
+	})
 	labels := make([]string, 0, len(allCandidates))
 	byLabel := make(map[string]sourcedPasswordManagerCandidate, len(allCandidates))
 	defaultLabels := make([]string, 0, len(sites))
+	remainingDefaults := availableConnections
 	domainCounts := make(map[string]int, len(sites))
 	for _, sourced := range allCandidates {
 		domainCounts[sourced.candidate.Domain]++
@@ -481,7 +580,25 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 		labels = append(labels, label)
 		byLabel[label] = sourced
 		if domainCounts[candidate.Domain] == 1 {
+			if !existing[candidateKey(candidate)] && remainingDefaults == 0 {
+				continue
+			}
 			defaultLabels = append(defaultLabels, label)
+			if !existing[candidateKey(candidate)] {
+				remainingDefaults--
+			}
+		}
+	}
+	if requested != "" && nonInteractive {
+		requiredNew := 0
+		for _, sourced := range allCandidates {
+			candidate := sourced.candidate
+			if domainCounts[candidate.Domain] == 1 && !existing[candidateKey(candidate)] {
+				requiredNew++
+			}
+		}
+		if requiredNew > availableConnections {
+			return pendingManagedAuth{}, fmt.Errorf("%d matching logins need new Managed Auth connections, but your organization has %d slot%s available", requiredNew, availableConnections, pluralSuffix(availableConnections))
 		}
 	}
 	if nonInteractive {
@@ -494,7 +611,8 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 	chosenLabels := defaultLabels
 	if !nonInteractive {
 		for {
-			selected, promptErr := c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", "Choose at most one login per website", labels, chosenLabels)
+			prompt := "Choose logins for Managed Auth (existing connections do not use a new slot)"
+			selected, promptErr := c.prompter.MultiSelect("logins", "pass --yes to approve suggested matches", prompt, labels, chosenLabels)
 			if promptErr != nil {
 				return pendingManagedAuth{}, promptErr
 			}
@@ -503,9 +621,17 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 				chosenLabels = selected
 				continue
 			}
+			if excess := selectedNewConnectionCount(selected, byLabel, existing) - availableConnections; excess > 0 {
+				pterm.Warning.Printf("Your selection needs %d more Managed Auth connection slot%s; your selections are preserved\n", excess, pluralSuffix(excess))
+				chosenLabels = selected
+				continue
+			}
 			chosenLabels = selected
 			break
 		}
+	}
+	if selectedNewConnectionCount(chosenLabels, byLabel, existing) > availableConnections {
+		return pendingManagedAuth{}, fmt.Errorf("select at most %d new Managed Auth login%s", availableConnections, pluralSuffix(availableConnections))
 	}
 	approvedByProvider := make(map[string][]passwordmanager.Candidate, len(chosenProviders))
 	selectedDomains := make(map[string]struct{}, len(chosenLabels))
@@ -525,6 +651,31 @@ func (c ProfilesImportLocalCmd) chooseManagedAuthLogins(ctx context.Context, sit
 		}
 	}
 	return pending, nil
+}
+
+func managedAuthDiscoveryFailure(requested, action string, err error) error {
+	if requested == "" {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+func selectedNewConnectionCount(labels []string, byLabel map[string]sourcedPasswordManagerCandidate, existing map[string]bool) int {
+	count := 0
+	for _, label := range labels {
+		candidate := byLabel[label].candidate
+		if !existing[candidateKey(candidate)] {
+			count++
+		}
+	}
+	return count
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func discoverProviderCandidates(ctx context.Context, provider passwordmanager.Provider, sites []string, nonInteractive, humanOutput bool) ([]passwordmanager.Candidate, error) {
@@ -676,15 +827,12 @@ func (c ProfilesImportLocalCmd) chooseProfile(profiles []localbrowser.Profile, r
 	return localbrowser.Profile{}, fmt.Errorf("selected browser profile is unavailable")
 }
 
-func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requested []string, count int, skipPrompt bool) ([]string, error) {
+func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requested []string, skipPrompt bool) ([]string, error) {
 	if len(requested) > 0 {
 		return normalizeSites(requested)
 	}
-	if len(recent) < count {
-		count = len(recent)
-	}
-	defaults := make([]string, 0, count)
-	for _, site := range recent[:count] {
+	defaults := make([]string, 0, len(recent))
+	for _, site := range recent {
 		defaults = append(defaults, site.Domain)
 	}
 	if skipPrompt {
@@ -692,14 +840,12 @@ func (c ProfilesImportLocalCmd) chooseSites(recent []localbrowser.Site, requeste
 	}
 	labels := make([]string, 0, len(recent))
 	byLabel := make(map[string]string, len(recent))
-	defaultLabels := make([]string, 0, count)
-	for index, site := range recent {
+	defaultLabels := make([]string, 0, len(recent))
+	for _, site := range recent {
 		label := cookieSiteLabel(site)
 		labels = append(labels, label)
 		byLabel[label] = site.Domain
-		if index < count {
-			defaultLabels = append(defaultLabels, label)
-		}
+		defaultLabels = append(defaultLabels, label)
 	}
 	chosen, err := c.prompter.MultiSelect("websites", "pass --sites or --yes", "Choose websites whose cookies should be imported", labels, defaultLabels)
 	if err != nil {
@@ -731,6 +877,14 @@ func sitesWithCookies(sites []localbrowser.Site) []localbrowser.Site {
 		if site.CookieCount > 0 {
 			result = append(result, site)
 		}
+	}
+	return result
+}
+
+func offeredCookieSites(sites []localbrowser.Site, count int) []localbrowser.Site {
+	result := sitesWithCookies(sites)
+	if len(result) > count {
+		return result[:count]
 	}
 	return result
 }
@@ -885,7 +1039,7 @@ func init() {
 	profilesImportLocalCmd.Flags().String("browser-profile", "", "Local browser profile ID or name")
 	profilesImportLocalCmd.Flags().String("profile-name", "", "Kernel profile name")
 	profilesImportLocalCmd.Flags().StringSlice("sites", nil, "Website domains to import (up to 10)")
-	profilesImportLocalCmd.Flags().Int("count", 5, "Number of recent websites selected by default (5-10)")
+	profilesImportLocalCmd.Flags().Int("count", 10, "Number of recent websites to offer (5-10); all are selected by default")
 	profilesImportLocalCmd.Flags().Int("days", 30, "Rank websites used during the last number of days (1-90)")
 	profilesImportLocalCmd.Flags().Duration("wait-timeout", 30*time.Minute, "Maximum time to wait for the import to complete")
 	profilesImportLocalCmd.Flags().BoolP("yes", "y", false, "Use suggested websites and skip confirmation")
@@ -941,7 +1095,13 @@ func runProfilesImportLocalWithInput(cmd *cobra.Command, input ProfilesImportLoc
 	}
 	credentials := projectClient.Credentials
 	connections := projectClient.Auth.Connections
-	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter(), providers: passwordmanager.Detect, provisioner: kernelManagedAuthProvisioner{credentials: &credentials, connections: &connections}}
+	limits := projectClient.Organization.Limits
+	c := ProfilesImportLocalCmd{
+		prompter:            interactive.NewPrompter(),
+		providers:           passwordmanager.Detect,
+		provisioner:         kernelManagedAuthProvisioner{credentials: &credentials, connections: &connections},
+		managedAuthCapacity: func(ctx context.Context) (managedAuthCapacity, error) { return loadManagedAuthCapacity(ctx, &limits) },
+	}
 	input.ProjectID = project.ID
 	if input.Version == "" {
 		input.Version = metadata.Version

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"regexp"
 	"runtime"
@@ -39,6 +41,7 @@ type ProfilesImportLocalInput struct {
 	WaitTimeout        time.Duration
 	PasswordManager    string
 	InstallAgentSkills bool
+	DashboardLaunch    bool
 }
 
 type ProfilesImportLocalCmd struct {
@@ -61,6 +64,13 @@ type pendingProviderLogins struct {
 type sourcedPasswordManagerCandidate struct {
 	provider  passwordmanager.Provider
 	candidate passwordmanager.Candidate
+}
+
+var errRequestedProjectUnavailable = errors.New("requested Kernel project is not active or available")
+
+func dashboardProjectAuthRecovery(err error) bool {
+	var apiError *kernel.Error
+	return errors.Is(err, errRequestedProjectUnavailable) || (errors.As(err, &apiError) && apiError.StatusCode == http.StatusUnauthorized)
 }
 
 func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
@@ -794,16 +804,13 @@ func projectOptionLabel(index int, project kernel.Project) string {
 	return fmt.Sprintf("%2d  %s", index+1, compactField(project.Name, 48))
 }
 
-func chooseImportProject(ctx context.Context, projects ProjectListService, prompter interactive.Prompter, requested string, nonInteractive bool) (string, error) {
-	if requested != "" {
-		return requested, nil
-	}
+func chooseImportProject(ctx context.Context, projects ProjectListService, prompter interactive.Prompter, requested string, nonInteractive bool) (kernel.Project, error) {
 	const pageSize int64 = 100
 	active := make([]kernel.Project, 0)
 	for offset := int64(0); ; {
 		page, err := projects.List(ctx, kernel.ProjectListParams{Limit: param.NewOpt(pageSize), Offset: param.NewOpt(offset)})
 		if err != nil {
-			return "", fmt.Errorf("list Kernel projects: %w", err)
+			return kernel.Project{}, fmt.Errorf("list Kernel projects: %w", err)
 		}
 		if page == nil || len(page.Items) == 0 {
 			break
@@ -818,25 +825,33 @@ func chooseImportProject(ctx context.Context, projects ProjectListService, promp
 		}
 		offset += int64(len(page.Items))
 	}
+	if requested != "" {
+		for _, project := range active {
+			if project.ID == requested {
+				return project, nil
+			}
+		}
+		return kernel.Project{}, fmt.Errorf("%w: %q", errRequestedProjectUnavailable, requested)
+	}
 	if len(active) == 0 {
-		return "", fmt.Errorf("no active Kernel projects were found")
+		return kernel.Project{}, fmt.Errorf("no active Kernel projects were found")
 	}
 	if len(active) == 1 {
-		return active[0].ID, nil
+		return active[0], nil
 	}
 	if nonInteractive {
-		return "", fmt.Errorf("multiple Kernel projects are available; pass --project")
+		return kernel.Project{}, fmt.Errorf("multiple Kernel projects are available; pass --project")
 	}
 	options := make([]string, 0, len(active))
-	byOption := make(map[string]string, len(active))
+	byOption := make(map[string]kernel.Project, len(active))
 	for index, project := range active {
 		label := projectOptionLabel(index, project)
 		options = append(options, label)
-		byOption[label] = project.ID
+		byOption[label] = project
 	}
 	chosen, err := prompter.Select("Kernel project", "pass --project", "Choose the Kernel project for this import", options)
 	if err != nil {
-		return "", err
+		return kernel.Project{}, err
 	}
 	return byOption[chosen], nil
 }
@@ -887,14 +902,27 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	installAgentSkills, _ := cmd.Flags().GetBool("install-agent-skills")
 	output, _ := cmd.Flags().GetString("output")
 	project, _ := cmd.Flags().GetString("project")
-	project = resolveProjectSelection(project)
+	return runProfilesImportLocalWithInput(cmd, ProfilesImportLocalInput{
+		BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days,
+		SkipConfirm: skipConfirm, Output: output, ProjectID: resolveProjectSelection(project), Version: metadata.Version,
+		WaitTimeout: waitTimeout, PasswordManager: passwordManager, InstallAgentSkills: installAgentSkills,
+	})
+}
+
+func runProfilesImportLocalWithInput(cmd *cobra.Command, input ProfilesImportLocalInput) error {
 	client := getKernelClient(cmd)
-	project, err := chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), project, skipConfirm || output == "json")
+	project, err := chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), input.ProjectID, input.SkipConfirm || input.Output == "json")
 	if err != nil {
+		if input.DashboardLaunch && dashboardProjectAuthRecovery(err) {
+			return fmt.Errorf("validate dashboard project: %w; if this is the wrong account, run `kernel login --force` (and unset KERNEL_API_KEY if set), then open the import again", err)
+		}
 		return err
 	}
+	if input.DashboardLaunch && input.Output != "json" {
+		pterm.Success.Printf("Connected to Kernel project %s\n", compactField(project.Name, 48))
+	}
 	projectClient, err := auth.GetAuthenticatedClient(
-		option.WithProjectID(project),
+		option.WithProjectID(project.ID),
 		option.WithHeader("X-Kernel-Cli-Version", metadata.Version),
 	)
 	if err != nil {
@@ -903,5 +931,9 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 	credentials := projectClient.Credentials
 	connections := projectClient.Auth.Connections
 	c := ProfilesImportLocalCmd{prompter: interactive.NewPrompter(), providers: passwordmanager.Detect, provisioner: kernelManagedAuthProvisioner{credentials: &credentials, connections: &connections}}
-	return c.Run(cmd.Context(), ProfilesImportLocalInput{BrowserProfile: browserProfile, ProfileName: profileName, Sites: sites, Count: count, Days: days, SkipConfirm: skipConfirm, Output: output, ProjectID: project, Version: metadata.Version, WaitTimeout: waitTimeout, PasswordManager: passwordManager, InstallAgentSkills: installAgentSkills})
+	input.ProjectID = project.ID
+	if input.Version == "" {
+		input.Version = metadata.Version
+	}
+	return c.Run(cmd.Context(), input)
 }

--- a/cmd/profiles_import_local.go
+++ b/cmd/profiles_import_local.go
@@ -42,6 +42,7 @@ type ProfilesImportLocalInput struct {
 	PasswordManager    string
 	InstallAgentSkills bool
 	DashboardLaunch    bool
+	Project            *kernel.Project
 }
 
 type ProfilesImportLocalCmd struct {
@@ -69,8 +70,12 @@ type sourcedPasswordManagerCandidate struct {
 var errRequestedProjectUnavailable = errors.New("requested Kernel project is not active or available")
 
 func dashboardProjectAuthRecovery(err error) bool {
+	return errors.Is(err, errRequestedProjectUnavailable) || dashboardProjectUnauthorized(err)
+}
+
+func dashboardProjectUnauthorized(err error) bool {
 	var apiError *kernel.Error
-	return errors.Is(err, errRequestedProjectUnavailable) || (errors.As(err, &apiError) && apiError.StatusCode == http.StatusUnauthorized)
+	return errors.As(err, &apiError) && apiError.StatusCode == http.StatusUnauthorized
 }
 
 func (c ProfilesImportLocalCmd) Run(ctx context.Context, in ProfilesImportLocalInput) error {
@@ -911,12 +916,18 @@ func runProfilesImportLocal(cmd *cobra.Command, _ []string) error {
 
 func runProfilesImportLocalWithInput(cmd *cobra.Command, input ProfilesImportLocalInput) error {
 	client := getKernelClient(cmd)
-	project, err := chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), input.ProjectID, input.SkipConfirm || input.Output == "json")
-	if err != nil {
-		if input.DashboardLaunch && dashboardProjectAuthRecovery(err) {
-			return fmt.Errorf("validate dashboard project: %w; if this is the wrong account, run `kernel login --force` (and unset KERNEL_API_KEY if set), then open the import again", err)
+	var project kernel.Project
+	if input.Project != nil {
+		project = *input.Project
+	} else {
+		var err error
+		project, err = chooseImportProject(cmd.Context(), &client.Projects, interactive.NewPrompter(), input.ProjectID, input.SkipConfirm || input.Output == "json")
+		if err != nil {
+			if input.DashboardLaunch && dashboardProjectAuthRecovery(err) {
+				return fmt.Errorf("validate dashboard project: %w; if this is the wrong account, run `kernel login --force` (and unset KERNEL_API_KEY if set), then open the import again", err)
+			}
+			return err
 		}
-		return err
 	}
 	if input.DashboardLaunch && input.Output != "json" {
 		pterm.Success.Printf("Connected to Kernel project %s\n", compactField(project.Name, 48))

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -112,6 +112,37 @@ type fakePasswordManager struct {
 	err        error
 }
 
+type fakeManagedAuthProvisioner struct {
+	existing map[string]bool
+	err      error
+}
+
+func (f fakeManagedAuthProvisioner) Existing(_ context.Context, _ string, candidates []passwordmanager.Candidate) (map[string]bool, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	result := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		result[candidateKey(candidate)] = f.existing[candidateKey(candidate)]
+	}
+	return result, nil
+}
+
+func (fakeManagedAuthProvisioner) Provision(context.Context, string, []passwordmanager.Record) ([]string, error) {
+	return nil, nil
+}
+
+func managedAuthTestCommand(providers func() []passwordmanager.Provider, remaining int) ProfilesImportLocalCmd {
+	return ProfilesImportLocalCmd{
+		prompter:    interactive.NewPrompterWithTerminal(false),
+		providers:   providers,
+		provisioner: fakeManagedAuthProvisioner{},
+		managedAuthCapacity: func(context.Context) (managedAuthCapacity, error) {
+			return managedAuthCapacity{remaining: remaining}, nil
+		},
+	}
+}
+
 func (f fakePasswordManager) Name() string {
 	if f.name != "" {
 		return f.name
@@ -135,24 +166,24 @@ func TestChooseManagedAuthLoginsRequiresChoiceForAmbiguousSite(t *testing.T) {
 		{ID: "two", Domain: "github.com", Username: "two", Name: "Two"},
 		{ID: "three", Domain: "example.com", Username: "three", Name: "Three"},
 	}
-	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
 		return []passwordmanager.Provider{fakePasswordManager{candidates: records}}
-	}}
-	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com", "example.com"}, "bitwarden", true, false)
+	}, 2)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, "bitwarden", true, false)
 	require.Error(t, err)
 	assert.Empty(t, selected.providers)
 	assert.Contains(t, err.Error(), "github.com has 2 matching logins")
 }
 
 func TestChooseManagedAuthLoginsCombinesSelectedProviders(t *testing.T) {
-	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
 		return []passwordmanager.Provider{
 			fakePasswordManager{name: "Bitwarden", candidates: []passwordmanager.Candidate{{ID: "bw", Domain: "github.com", Name: "GitHub personal"}}},
 			fakePasswordManager{name: "1Password", candidates: []passwordmanager.Candidate{{ID: "op", Domain: "example.com", Name: "Example work"}}},
 		}
-	}}
+	}, 2)
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com", "example.com"}, "bitwarden,1password", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, "bitwarden,1password", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 2)
 	assert.Equal(t, "Bitwarden", selected.providers[0].provider.Name())
@@ -162,13 +193,13 @@ func TestChooseManagedAuthLoginsCombinesSelectedProviders(t *testing.T) {
 }
 
 func TestChooseManagedAuthLoginsDeduplicatesRequestedProviders(t *testing.T) {
-	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false), providers: func() []passwordmanager.Provider {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
 		return []passwordmanager.Provider{
 			fakePasswordManager{name: "Bitwarden", candidates: []passwordmanager.Candidate{{ID: "bw", Domain: "github.com", Name: "GitHub personal"}}},
 		}
-	}}
+	}, 1)
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), []string{"github.com"}, "bitwarden,bitwarden", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com"}, "bitwarden,bitwarden", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 1)
 	require.Len(t, selected.providers[0].candidates, 1)
@@ -197,20 +228,128 @@ func TestDuplicateSelectedDomainAcrossProviders(t *testing.T) {
 
 func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	selected, err := command.chooseSites(nil, []string{"github.com"}, 5, false)
+	selected, err := command.chooseSites(nil, []string{"github.com"}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"github.com"}, selected)
 }
 
-func TestChooseSitesUsesTopFiveWithYes(t *testing.T) {
+func TestChooseSitesUsesEveryRankedSiteWithYes(t *testing.T) {
 	recent := make([]localbrowser.Site, 0, 7)
 	for _, domain := range []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"} {
 		recent = append(recent, localbrowser.Site{Domain: domain})
 	}
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	selected, err := command.chooseSites(recent, nil, 5, true)
+	selected, err := command.chooseSites(recent, nil, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com"}, selected)
+	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"}, selected)
+}
+
+func TestDecodeManagedAuthCapacity(t *testing.T) {
+	t.Run("remaining", func(t *testing.T) {
+		capacity, err := decodeManagedAuthCapacity(`{"max_auth_connections":5,"auth_connections_used":3}`)
+		require.NoError(t, err)
+		assert.Equal(t, managedAuthCapacity{remaining: 2}, capacity)
+	})
+	t.Run("at limit", func(t *testing.T) {
+		capacity, err := decodeManagedAuthCapacity(`{"max_auth_connections":3,"auth_connections_used":4}`)
+		require.NoError(t, err)
+		assert.Equal(t, managedAuthCapacity{}, capacity)
+	})
+	t.Run("unlimited", func(t *testing.T) {
+		capacity, err := decodeManagedAuthCapacity(`{"max_auth_connections":null,"auth_connections_used":329}`)
+		require.NoError(t, err)
+		assert.Equal(t, managedAuthCapacity{unlimited: true}, capacity)
+	})
+	t.Run("old API", func(t *testing.T) {
+		_, err := decodeManagedAuthCapacity(`{"max_concurrent_sessions":10}`)
+		require.ErrorContains(t, err, "deploy the organization entitlements API first")
+	})
+}
+
+func TestChooseManagedAuthLoginsRejectsExplicitBatchAboveRemainingConnections(t *testing.T) {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{
+			{ID: "one", Domain: "one.com", Name: "One"},
+			{ID: "two", Domain: "two.com", Name: "Two"},
+			{ID: "three", Domain: "three.com", Name: "Three"},
+		}}}
+	}, 2)
+
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com", "three.com"}, "bitwarden", true, false)
+	require.ErrorContains(t, err, "3 matching logins need new Managed Auth connections")
+}
+
+func TestChooseManagedAuthLoginsRefreshesExistingConnectionAtLimit(t *testing.T) {
+	candidate := passwordmanager.Candidate{Provider: "bitwarden", ID: "existing", Domain: "one.com", Name: "Existing"}
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{candidate}}}
+	}, 0)
+	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(candidate): true}}
+
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	require.NoError(t, err)
+	require.Len(t, selected.providers, 1)
+	assert.Equal(t, "existing", selected.providers[0].candidates[0].ID)
+}
+
+func TestChooseManagedAuthLoginsRefreshesExistingWhenCapacityLookupFails(t *testing.T) {
+	candidate := passwordmanager.Candidate{Provider: "1password", VaultID: "vault", ID: "existing", Domain: "one.com", Name: "Existing"}
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{name: "1Password", candidates: []passwordmanager.Candidate{candidate}}}
+	}, 0)
+	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(candidate): true}}
+	command.managedAuthCapacity = func(context.Context) (managedAuthCapacity, error) { return managedAuthCapacity{}, assert.AnError }
+
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "1password", true, false)
+	require.NoError(t, err)
+	require.Len(t, selected.providers, 1)
+	assert.Equal(t, "existing", selected.providers[0].candidates[0].ID)
+}
+
+func TestChooseManagedAuthLoginsRejectsExplicitImportAtLimit(t *testing.T) {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{{Provider: "bitwarden", ID: "new", Domain: "one.com"}}}}
+	}, 0)
+
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	require.ErrorContains(t, err, "no Managed Auth connection slots available")
+}
+
+func TestChooseManagedAuthLoginsRejectsMixedExplicitBatchAtLimit(t *testing.T) {
+	existingCandidate := passwordmanager.Candidate{Provider: "bitwarden", ID: "existing", Domain: "one.com"}
+	newCandidate := passwordmanager.Candidate{Provider: "bitwarden", ID: "new", Domain: "two.com"}
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{existingCandidate, newCandidate}}}
+	}, 0)
+	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(existingCandidate): true}}
+
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, "bitwarden", true, false)
+	require.ErrorContains(t, err, "no Managed Auth connection slots available for new logins")
+}
+
+func TestChooseManagedAuthLoginsRejectsExplicitBatchLargerThanCapacity(t *testing.T) {
+	command := managedAuthTestCommand(func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{
+			{Provider: "bitwarden", ID: "one", Domain: "one.com"},
+			{Provider: "bitwarden", ID: "two", Domain: "two.com"},
+		}}}
+	}, 1)
+
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, "bitwarden", true, false)
+	require.ErrorContains(t, err, "2 matching logins need new Managed Auth connections")
+}
+
+func TestChooseManagedAuthLoginsClassificationFailurePolicy(t *testing.T) {
+	provider := func() []passwordmanager.Provider {
+		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{{Provider: "bitwarden", ID: "new", Domain: "one.com"}}}}
+	}
+	command := managedAuthTestCommand(provider, 1)
+	command.provisioner = fakeManagedAuthProvisioner{err: assert.AnError}
+
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	require.ErrorContains(t, err, "check existing Managed Auth connections")
+	assert.NoError(t, managedAuthDiscoveryFailure("", "check existing Managed Auth connections", assert.AnError))
+	require.Error(t, managedAuthDiscoveryFailure("bitwarden", "check existing Managed Auth connections", assert.AnError))
 }
 
 func TestCookieSiteLabelShowsRankingAndCookieCount(t *testing.T) {
@@ -232,9 +371,20 @@ func TestSitesWithCookiesOmitsEmptySitesAndPreservesRanking(t *testing.T) {
 	assert.Equal(t, []string{"first.com", "second.com"}, []string{sites[0].Domain, sites[1].Domain})
 }
 
+func TestOfferedCookieSitesBackfillsAfterEmptyRankedSites(t *testing.T) {
+	sites := offeredCookieSites([]localbrowser.Site{
+		{Domain: "empty-first.com", Visits: 100},
+		{Domain: "first.com", Visits: 90, CookieCount: 2},
+		{Domain: "empty-second.com", Visits: 80},
+		{Domain: "second.com", Visits: 70, CookieCount: 1},
+		{Domain: "third.com", Visits: 60, CookieCount: 1},
+	}, 2)
+	assert.Equal(t, []string{"first.com", "second.com"}, []string{sites[0].Domain, sites[1].Domain})
+}
+
 func TestChooseSitesFailsFastWithoutTTYOrFlags(t *testing.T) {
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	_, err := command.chooseSites([]localbrowser.Site{{Domain: "example.com"}}, nil, 5, false)
+	_, err := command.chooseSites([]localbrowser.Site{{Domain: "example.com"}}, nil, false)
 	var promptError *interactive.PromptError
 	require.ErrorAs(t, err, &promptError)
 	assert.Contains(t, promptError.Error(), "pass --sites or --yes")

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
@@ -14,6 +16,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDashboardProjectAuthRecovery(t *testing.T) {
+	t.Parallel()
+	assert.True(t, dashboardProjectAuthRecovery(errRequestedProjectUnavailable))
+	assert.True(t, dashboardProjectAuthRecovery(&kernel.Error{StatusCode: http.StatusUnauthorized}))
+	assert.False(t, dashboardProjectAuthRecovery(&kernel.Error{StatusCode: http.StatusInternalServerError}))
+	assert.False(t, dashboardProjectAuthRecovery(errors.New("network unavailable")))
+}
 
 type fakeProjectListService struct{ projects []kernel.Project }
 
@@ -33,7 +43,22 @@ func TestChooseImportProjectUsesOnlyActiveProject(t *testing.T) {
 		{ID: "active", Name: "Default", Status: kernel.ProjectStatusActive},
 	}}, interactive.NewPrompterWithTerminal(false), "", false)
 	require.NoError(t, err)
-	assert.Equal(t, "active", project)
+	assert.Equal(t, "active", project.ID)
+}
+
+func TestChooseImportProjectValidatesRequestedProject(t *testing.T) {
+	projects := fakeProjectListService{projects: []kernel.Project{
+		{ID: "active", Name: "Available", Status: kernel.ProjectStatusActive},
+		{ID: "archived", Name: "Archived", Status: kernel.ProjectStatusArchived},
+	}}
+	project, err := chooseImportProject(t.Context(), projects, interactive.NewPrompterWithTerminal(false), "active", true)
+	require.NoError(t, err)
+	assert.Equal(t, "Available", project.Name)
+
+	_, err = chooseImportProject(t.Context(), projects, interactive.NewPrompterWithTerminal(false), "archived", true)
+	require.ErrorIs(t, err, errRequestedProjectUnavailable)
+	_, err = chooseImportProject(t.Context(), projects, interactive.NewPrompterWithTerminal(false), "missing", true)
+	require.ErrorIs(t, err, errRequestedProjectUnavailable)
 }
 
 func TestChooseImportProjectRequiresFlagForMultipleNonInteractiveProjects(t *testing.T) {

--- a/cmd/profiles_import_local_test.go
+++ b/cmd/profiles_import_local_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -75,29 +76,69 @@ func TestCompactFieldPreventsLoginRowsFromWrapping(t *testing.T) {
 	assert.LessOrEqual(t, ansi.StringWidth(compactField("界界界界界", 6)), 6)
 	assert.Equal(t, "safe fake", compactField("\x1b[31msafe\x1b[0m\n\x1b]8;;https://example.com\x07fake\x1b]8;;\x07", 20))
 
-	label := loginCandidateLabel(1, "Bitwarden", passwordmanager.Candidate{
-		Domain:   "accounts.google.com",
-		Username: "same-account@example.com",
-		Name:     "personal google account",
-	}, "abc123")
-	assert.LessOrEqual(t, ansi.StringWidth(label), 72)
-	assert.Contains(t, label, "personal google")
+}
 
-	withoutUsername := loginCandidateLabel(2, "1Password", passwordmanager.Candidate{
-		Domain: "example.com",
-		Name:   "personal account",
-	}, "def456")
-	assert.Contains(t, withoutUsername, "no username")
-	assert.Contains(t, withoutUsername, "personal account")
+func TestGroupedLoginCandidateLabelIsReadableAndBounded(t *testing.T) {
+	label := groupedLoginCandidateLabel("Bitwarden", passwordmanager.Candidate{
+		ID:       "a-very-long-stable-provider-item-id",
+		Username: "ilyaas@kernel.sh",
+		Name:     "Google Work Account",
+	})
+	assert.Contains(t, label, "BW")
+	assert.Contains(t, label, "ilyaas@kernel.sh")
+	assert.Contains(t, label, "Google Work Account")
+	assert.LessOrEqual(t, ansi.StringWidth(label), 68)
+}
 
-	for _, index := range []int{999, 9999} {
-		label := loginCandidateLabel(index, "Bitwarden", passwordmanager.Candidate{
-			Domain:   "accounts.google.com",
-			Username: "same-account@example.com",
-			Name:     "personal google account",
-		}, "abc123")
-		assert.LessOrEqual(t, ansi.StringWidth(label), 72)
+func TestGroupedLoginLabelsUseIDsOnlyToResolveCollisions(t *testing.T) {
+	provider := fakePasswordManager{name: "Bitwarden"}
+	labels := groupedLoginLabels([]sourcedPasswordManagerCandidate{
+		{provider: provider, candidate: passwordmanager.Candidate{ID: "first-item-abcdef", Username: "same", Name: "same"}},
+		{provider: provider, candidate: passwordmanager.Candidate{ID: "second-item-abcdef", Username: "same", Name: "same"}},
+	})
+	require.Len(t, labels, 2)
+	assert.NotEqual(t, labels[0], labels[1])
+	assert.NotContains(t, labels[0], "1  BW")
+}
+
+func TestManagedAuthNewChoiceCountDoesNotChargeExistingConnections(t *testing.T) {
+	provider := fakePasswordManager{name: "Bitwarden"}
+	existingCandidate := passwordmanager.Candidate{Provider: "bitwarden", ID: "existing", Domain: "one.com"}
+	newCandidate := passwordmanager.Candidate{Provider: "bitwarden", ID: "new", Domain: "two.com"}
+	choices := map[string]sourcedPasswordManagerCandidate{
+		"one.com": {provider: provider, candidate: existingCandidate},
+		"two.com": {provider: provider, candidate: newCandidate},
 	}
+	assert.Equal(t, 1, managedAuthNewChoiceCount(choices, map[string]bool{candidateKey(existingCandidate): true}))
+}
+
+func TestPreviousAmbiguousDomainSkipsAutoSelectedWebsites(t *testing.T) {
+	provider := fakePasswordManager{name: "Bitwarden"}
+	candidate := func(id, domain string) sourcedPasswordManagerCandidate {
+		return sourcedPasswordManagerCandidate{provider: provider, candidate: passwordmanager.Candidate{ID: id, Domain: domain}}
+	}
+	domains := []string{"one.com", "two.com", "three.com", "four.com"}
+	byDomain := map[string][]sourcedPasswordManagerCandidate{
+		"one.com":   {candidate("1a", "one.com"), candidate("1b", "one.com")},
+		"two.com":   {candidate("2", "two.com")},
+		"three.com": {candidate("3", "three.com")},
+		"four.com":  {candidate("4a", "four.com"), candidate("4b", "four.com")},
+	}
+	assert.Equal(t, 0, previousAmbiguousDomainIndex(domains, byDomain, 3))
+	assert.Equal(t, -1, previousAmbiguousDomainIndex(domains, byDomain, 0))
+}
+
+func TestManagedAuthCandidateIdentityPrefersUsername(t *testing.T) {
+	assert.Equal(t, "me@example.com", managedAuthCandidateIdentity(passwordmanager.Candidate{Username: "me@example.com", Name: "Example"}))
+	assert.Equal(t, "Example", managedAuthCandidateIdentity(passwordmanager.Candidate{Name: "Example"}))
+}
+
+func TestImportedCookieSiteCountUsesRegistrableDomains(t *testing.T) {
+	assert.Equal(t, 2, importedCookieSiteCount([]localbrowser.Cookie{
+		{Domain: ".google.com"},
+		{Domain: "accounts.google.com"},
+		{Domain: ".github.com"},
+	}))
 }
 
 func TestProjectOptionLabelsAreUniqueForDuplicateNames(t *testing.T) {
@@ -169,7 +210,7 @@ func TestChooseManagedAuthLoginsRequiresChoiceForAmbiguousSite(t *testing.T) {
 	command := managedAuthTestCommand(func() []passwordmanager.Provider {
 		return []passwordmanager.Provider{fakePasswordManager{candidates: records}}
 	}, 2)
-	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, "bitwarden", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, nil, "bitwarden", true, false)
 	require.Error(t, err)
 	assert.Empty(t, selected.providers)
 	assert.Contains(t, err.Error(), "github.com has 2 matching logins")
@@ -183,7 +224,7 @@ func TestChooseManagedAuthLoginsCombinesSelectedProviders(t *testing.T) {
 		}
 	}, 2)
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, "bitwarden,1password", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com", "example.com"}, nil, "bitwarden,1password", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 2)
 	assert.Equal(t, "Bitwarden", selected.providers[0].provider.Name())
@@ -199,7 +240,7 @@ func TestChooseManagedAuthLoginsDeduplicatesRequestedProviders(t *testing.T) {
 		}
 	}, 1)
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com"}, "bitwarden,bitwarden", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"github.com"}, nil, "bitwarden,bitwarden", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 1)
 	require.Len(t, selected.providers[0].candidates, 1)
@@ -215,33 +256,110 @@ func TestChooseManagedAuthLoginsSkipsBrokenInteractiveProvider(t *testing.T) {
 	require.Len(t, healthy, 1)
 }
 
-func TestDuplicateSelectedDomainAcrossProviders(t *testing.T) {
-	provider := fakePasswordManager{name: "Bitwarden"}
-	candidates := map[string]sourcedPasswordManagerCandidate{
-		"bitwarden": {provider: provider, candidate: passwordmanager.Candidate{Domain: "google.com"}},
-		"1password": {provider: fakePasswordManager{name: "1Password"}, candidate: passwordmanager.Candidate{Domain: "google.com"}},
-	}
-
-	assert.Equal(t, "google.com", duplicateSelectedDomain([]string{"bitwarden", "1password"}, candidates))
-	assert.Empty(t, duplicateSelectedDomain([]string{"bitwarden"}, candidates))
-}
-
-func TestChooseSitesUsesRequestedDomainsWithoutPrompting(t *testing.T) {
+func TestChooseCookiesUsesRequestedDomainsWithoutPrompting(t *testing.T) {
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	selected, err := command.chooseSites(nil, []string{"github.com"}, false)
+	selection, err := command.chooseCookies(nil, []string{"github.com"}, false)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"github.com"}, selected)
+	assert.Equal(t, []string{"github.com"}, selection.sites)
+	assert.False(t, selection.all)
 }
 
-func TestChooseSitesUsesEveryRankedSiteWithYes(t *testing.T) {
+func TestChooseCookiesUsesAllCookiesWithYes(t *testing.T) {
 	recent := make([]localbrowser.Site, 0, 7)
 	for _, domain := range []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"} {
 		recent = append(recent, localbrowser.Site{Domain: domain})
 	}
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	selected, err := command.chooseSites(recent, nil, true)
+	selection, err := command.chooseCookies(recent, nil, true)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"}, selected)
+	assert.Equal(t, []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com", "seven.com"}, selection.sites)
+	assert.True(t, selection.all)
+}
+
+func TestCookieImportOptionsDefaultToAllCookies(t *testing.T) {
+	sites := []localbrowser.Site{
+		{Domain: "google.com", CookieCount: 63},
+		{Domain: "github.com", CookieCount: 15},
+	}
+
+	options := cookieImportOptions(sites)
+	require.Len(t, options, 2)
+	assert.Equal(t, "All cookies (recommended) — 78 cookies across 2 websites", options[0])
+	assert.Equal(t, "Choose websites", options[1])
+}
+
+func TestManagedAuthUsesOnlyTenMostUsedSelectedWebsites(t *testing.T) {
+	ranked := make([]localbrowser.Site, 0, 12)
+	selected := make([]string, 0, 12)
+	for i := range 11 {
+		domain := fmt.Sprintf("site-%02d.com", i)
+		ranked = append(ranked, localbrowser.Site{Domain: domain, Visits: 100 - i})
+		selected = append(selected, domain)
+	}
+	ranked = append(ranked, localbrowser.Site{Domain: "cookie-only.com"})
+	selected = append(selected, "cookie-only.com")
+
+	assert.Equal(t, selected[:10], rankedManagedAuthSites(ranked, selected, 10))
+}
+
+func TestManagedAuthUsesExplicitCookieSitesWithoutHistoryRanking(t *testing.T) {
+	selected := []string{"github.com", "google.com"}
+	assert.Equal(t, selected, rankedManagedAuthSites(nil, selected, 10))
+	assert.Equal(t, selected, rankedManagedAuthSites([]localbrowser.Site{{Domain: "github.com"}, {Domain: "google.com"}}, selected, 10))
+}
+
+func TestManagedAuthWebsiteDiscoveryDefaultsStaySelectedAtLimitedCapacity(t *testing.T) {
+	sites := []string{"one.com", "two.com", "three.com"}
+	prompt, defaults := managedAuthSitePrompt(sites, managedAuthCapacity{remaining: 2}, true)
+
+	assert.Contains(t, prompt, "2 new connection slots available")
+	assert.Equal(t, sites, defaults)
+}
+
+func TestManagedAuthWebsiteDefaultsStayOpenWhenCapacityIsUnknownOrUnlimited(t *testing.T) {
+	sites := []string{"one.com", "two.com", "three.com"}
+	_, unknownDefaults := managedAuthSitePrompt(sites, managedAuthCapacity{}, false)
+	_, unlimitedDefaults := managedAuthSitePrompt(sites, managedAuthCapacity{unlimited: true}, true)
+
+	assert.Equal(t, sites, unknownDefaults)
+	assert.Equal(t, sites, unlimitedDefaults)
+}
+
+func TestManagedAuthRecommendationOptionsShowRecentUse(t *testing.T) {
+	options, domains := managedAuthRecommendationOptions(
+		[]string{"github.com", "example.com"},
+		[]localbrowser.Site{{Domain: "github.com", Visits: 1475}},
+	)
+
+	require.Len(t, options, 2)
+	assert.Contains(t, options[0], "github.com")
+	assert.Contains(t, options[0], "1475 visits")
+	assert.Equal(t, "github.com", domains[options[0]])
+	assert.NotContains(t, options[1], "visits")
+}
+
+func TestManagedAuthSearchOptionsExcludeSelectedWebsites(t *testing.T) {
+	options, domains := managedAuthSearchOptions([]localbrowser.Site{
+		{Domain: "google.com", Visits: 20},
+		{Domain: "github.com", Visits: 10},
+	}, []string{"google.com"})
+
+	require.Len(t, options, 2)
+	assert.Equal(t, backOption, options[0])
+	assert.NotContains(t, domains, backOption)
+	assert.Contains(t, options[1], "github.com")
+	assert.Equal(t, "github.com", domains[options[1]])
+}
+
+func TestSelectedSiteMetadataPreservesRankAndExplicitSites(t *testing.T) {
+	metadata := selectedSiteMetadata(
+		[]localbrowser.Site{{Domain: "google.com", Visits: 20}, {Domain: "github.com", Visits: 10}},
+		[]string{"github.com", "manual.example"},
+	)
+
+	require.Len(t, metadata, 2)
+	assert.Equal(t, localbrowser.Site{Domain: "github.com", Visits: 10}, metadata[0])
+	assert.Equal(t, localbrowser.Site{Domain: "manual.example"}, metadata[1])
 }
 
 func TestDecodeManagedAuthCapacity(t *testing.T) {
@@ -275,7 +393,7 @@ func TestChooseManagedAuthLoginsRejectsExplicitBatchAboveRemainingConnections(t 
 		}}}
 	}, 2)
 
-	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com", "three.com"}, "bitwarden", true, false)
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com", "three.com"}, nil, "bitwarden", true, false)
 	require.ErrorContains(t, err, "3 matching logins need new Managed Auth connections")
 }
 
@@ -286,7 +404,7 @@ func TestChooseManagedAuthLoginsRefreshesExistingConnectionAtLimit(t *testing.T)
 	}, 0)
 	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(candidate): true}}
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, nil, "bitwarden", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 1)
 	assert.Equal(t, "existing", selected.providers[0].candidates[0].ID)
@@ -300,7 +418,7 @@ func TestChooseManagedAuthLoginsRefreshesExistingWhenCapacityLookupFails(t *test
 	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(candidate): true}}
 	command.managedAuthCapacity = func(context.Context) (managedAuthCapacity, error) { return managedAuthCapacity{}, assert.AnError }
 
-	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "1password", true, false)
+	selected, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, nil, "1password", true, false)
 	require.NoError(t, err)
 	require.Len(t, selected.providers, 1)
 	assert.Equal(t, "existing", selected.providers[0].candidates[0].ID)
@@ -311,7 +429,7 @@ func TestChooseManagedAuthLoginsRejectsExplicitImportAtLimit(t *testing.T) {
 		return []passwordmanager.Provider{fakePasswordManager{candidates: []passwordmanager.Candidate{{Provider: "bitwarden", ID: "new", Domain: "one.com"}}}}
 	}, 0)
 
-	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, nil, "bitwarden", true, false)
 	require.ErrorContains(t, err, "no Managed Auth connection slots available")
 }
 
@@ -323,7 +441,7 @@ func TestChooseManagedAuthLoginsRejectsMixedExplicitBatchAtLimit(t *testing.T) {
 	}, 0)
 	command.provisioner = fakeManagedAuthProvisioner{existing: map[string]bool{candidateKey(existingCandidate): true}}
 
-	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, "bitwarden", true, false)
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, nil, "bitwarden", true, false)
 	require.ErrorContains(t, err, "no Managed Auth connection slots available for new logins")
 }
 
@@ -335,7 +453,7 @@ func TestChooseManagedAuthLoginsRejectsExplicitBatchLargerThanCapacity(t *testin
 		}}}
 	}, 1)
 
-	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, "bitwarden", true, false)
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com", "two.com"}, nil, "bitwarden", true, false)
 	require.ErrorContains(t, err, "2 matching logins need new Managed Auth connections")
 }
 
@@ -346,40 +464,40 @@ func TestChooseManagedAuthLoginsClassificationFailurePolicy(t *testing.T) {
 	command := managedAuthTestCommand(provider, 1)
 	command.provisioner = fakeManagedAuthProvisioner{err: assert.AnError}
 
-	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, "bitwarden", true, false)
+	_, err := command.chooseManagedAuthLogins(context.Background(), "profile", []string{"one.com"}, nil, "bitwarden", true, false)
 	require.ErrorContains(t, err, "check existing Managed Auth connections")
 	assert.NoError(t, managedAuthDiscoveryFailure("", "check existing Managed Auth connections", assert.AnError))
 	require.Error(t, managedAuthDiscoveryFailure("bitwarden", "check existing Managed Auth connections", assert.AnError))
 }
 
 func TestCookieSiteLabelShowsRankingAndCookieCount(t *testing.T) {
-	label := cookieSiteLabel(localbrowser.Site{Domain: "google.com", Visits: 2347, CookieCount: 64})
+	label := cookieSiteLabel(0, localbrowser.Site{Domain: "google.com", Visits: 2347, CookieCount: 64})
+	assert.Contains(t, label, "1")
 	assert.Contains(t, label, "google.com")
 	assert.Contains(t, label, "2347 visits")
 	assert.Contains(t, label, "64 cookies")
 	assert.LessOrEqual(t, ansi.StringWidth(label), 64)
-	assert.LessOrEqual(t, ansi.StringWidth(cookieSiteLabel(localbrowser.Site{Domain: "界界界界界界界界界界界界界界界界", Visits: int(^uint(0) >> 1), CookieCount: int(^uint(0) >> 1)})), 64)
+	assert.LessOrEqual(t, ansi.StringWidth(cookieSiteLabel(9999, localbrowser.Site{Domain: "界界界界界界界界界界界界界界界界", Visits: int(^uint(0) >> 1), CookieCount: int(^uint(0) >> 1)})), 64)
 	assert.Equal(t, "1.00e+09", boundedCount(1_000_000_000))
 }
 
-func TestSitesWithCookiesOmitsEmptySitesAndPreservesRanking(t *testing.T) {
-	sites := sitesWithCookies([]localbrowser.Site{
-		{Domain: "first.com", Visits: 10, CookieCount: 2},
-		{Domain: "empty.com", Visits: 9},
-		{Domain: "second.com", Visits: 8, CookieCount: 1},
-	})
-	assert.Equal(t, []string{"first.com", "second.com"}, []string{sites[0].Domain, sites[1].Domain})
+func TestCookieSiteLabelsRemainUniqueWhenDomainsTruncateTheSame(t *testing.T) {
+	first := cookieSiteLabel(0, localbrowser.Site{Domain: "same-long-domain-prefix-one.example.com", Visits: 1, CookieCount: 1})
+	second := cookieSiteLabel(1, localbrowser.Site{Domain: "same-long-domain-prefix-two.example.com", Visits: 1, CookieCount: 1})
+	assert.NotEqual(t, first, second)
 }
 
-func TestOfferedCookieSitesBackfillsAfterEmptyRankedSites(t *testing.T) {
-	sites := offeredCookieSites([]localbrowser.Site{
-		{Domain: "empty-first.com", Visits: 100},
-		{Domain: "first.com", Visits: 90, CookieCount: 2},
-		{Domain: "empty-second.com", Visits: 80},
-		{Domain: "second.com", Visits: 70, CookieCount: 1},
-		{Domain: "third.com", Visits: 60, CookieCount: 1},
-	}, 2)
-	assert.Equal(t, []string{"first.com", "second.com"}, []string{sites[0].Domain, sites[1].Domain})
+func TestCookieRemovalOptionsDefaultToDoneAndIndexEveryWebsite(t *testing.T) {
+	options, byOption := cookieRemovalOptions([]localbrowser.Site{
+		{Domain: "google.com", CookieCount: 63},
+		{Domain: "github.com", CookieCount: 15},
+	})
+
+	assert.Equal(t, "Done — import 2 websites", options[0])
+	assert.Equal(t, backOption, options[1])
+	assert.NotContains(t, byOption, backOption)
+	assert.Equal(t, 0, byOption[options[2]])
+	assert.Equal(t, 1, byOption[options[3]])
 }
 
 func TestChooseSitesFailsFastWithoutTTYOrFlags(t *testing.T) {
@@ -397,7 +515,7 @@ func TestDefaultImportedProfileName(t *testing.T) {
 
 func TestProfilesImportLocalRejectsUnsupportedOutputBeforeDiscovery(t *testing.T) {
 	command := ProfilesImportLocalCmd{prompter: interactive.NewPrompterWithTerminal(false)}
-	err := command.Run(t.Context(), ProfilesImportLocalInput{Output: "yaml", Count: 5, Days: 30})
+	err := command.Run(t.Context(), ProfilesImportLocalInput{Output: "yaml", Days: 30})
 	assert.EqualError(t, err, `unsupported --output value "yaml"; use "json" or omit --output for human-readable output`)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,6 +96,10 @@ func isAuthExempt(cmd *cobra.Command) bool {
 	switch topLevel.Name() {
 	case "login", "logout", "help", "completion", "create", "mcp", "upgrade", "status":
 		return true
+	case "connector":
+		// The connector installs without auth and performs login-on-demand when
+		// opening a dashboard link.
+		return cmd == connectorInstallCmd || cmd == connectorOpenCmd
 	case "auth":
 		// Only exempt the auth command itself (status display), not its subcommands
 		return cmd == topLevel

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,10 @@ func isAuthExempt(cmd *cobra.Command) bool {
 	switch topLevel.Name() {
 	case "login", "logout", "help", "completion", "create", "mcp", "upgrade", "status":
 		return true
+	case "connector":
+		// The connector installs without auth and performs login-on-demand when
+		// opening a dashboard link.
+		return cmd == connectorInstallCmd || cmd == connectorOpenCmd
 	case "auth":
 		// Only exempt the auth command itself (status display), not its subcommands
 		return cmd == topLevel

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -34,6 +34,16 @@ func TestIsAuthExempt(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "connector install is exempt",
+			cmd:      connectorInstallCmd,
+			expected: true,
+		},
+		{
+			name:     "connector open handles login on demand",
+			cmd:      connectorOpenCmd,
+			expected: true,
+		},
+		{
 			name:     "browser-pools create subcommand requires auth",
 			cmd:      browserPoolsCreateCmd,
 			expected: false,

--- a/internal/browserimport/chromium.go
+++ b/internal/browserimport/chromium.go
@@ -183,8 +183,8 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 		return nil, err
 	}
 	defer cleanup()
-	siteClause := selectedCookieClause(selectedSites, true)
-	query := `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + whereClause + siteClause + ` ORDER BY host_key, name`
+	selectionCTE, siteClause := selectedCookieFilter(selectedSites, true)
+	query := selectionCTE + `SELECT host_key, path, name, value, hex(encrypted_value) AS encrypted_value, expires_utc, is_httponly, is_secure, samesite FROM cookies` + whereClause + siteClause + ` ORDER BY host_key, name`
 	data, err := sqliteJSON(ctx, snapshot, query)
 	if err != nil {
 		return nil, fmt.Errorf("read browser cookies: %w", err)
@@ -208,6 +208,11 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 	var key []byte
 	cookies := make([]Cookie, 0)
 	for _, row := range rows {
+		if len(selectedSites) == 0 {
+			if _, err := CanonicalSite(row.Domain); err != nil {
+				continue
+			}
+		}
 		if !matchesAnySite(row.Domain, selectedSites) {
 			continue
 		}
@@ -239,37 +244,57 @@ func ExportCookies(ctx context.Context, profile Profile, selectedSites []string)
 	return cookies, nil
 }
 
-// CountCookiesForSites counts importable cookies without reading or decrypting their values.
-func CountCookiesForSites(ctx context.Context, profile Profile, sites []Site) ([]Site, error) {
-	selected := make([]string, 0, len(sites))
-	for _, site := range sites {
-		selected = append(selected, site.Domain)
-	}
+// CookieSites returns every website with importable cookies, ranked by recent
+// browser use. It reads cookie metadata only; values are decrypted by
+// ExportCookies after the user chooses what to import.
+func CookieSites(ctx context.Context, profile Profile, recent []Site) ([]Site, error) {
 	snapshot, whereClause, cleanup, err := cookieDatabaseSnapshot(ctx, profile)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
-	data, err := sqliteJSON(ctx, snapshot, `SELECT host_key FROM cookies`+whereClause+selectedCookieClause(selected, true))
+	data, err := sqliteJSON(ctx, snapshot, `SELECT host_key, COUNT(*) AS cookie_count FROM cookies`+whereClause+` GROUP BY host_key`)
 	if err != nil {
-		return nil, fmt.Errorf("count browser cookies: %w", err)
+		return nil, fmt.Errorf("find browser cookie websites: %w", err)
 	}
 	var rows []struct {
-		Domain string `json:"host_key"`
+		Domain      string `json:"host_key"`
+		CookieCount int    `json:"cookie_count"`
 	}
 	if len(bytes.TrimSpace(data)) != 0 {
 		if err := json.Unmarshal(data, &rows); err != nil {
-			return nil, fmt.Errorf("decode browser cookie counts: %w", err)
+			return nil, fmt.Errorf("decode browser cookie websites: %w", err)
 		}
 	}
-	result := append([]Site(nil), sites...)
-	for i := range result {
-		for _, row := range rows {
-			if domainMatchesSite(row.Domain, result[i].Domain) {
-				result[i].CookieCount++
-			}
+	byDomain := make(map[string]Site, len(rows))
+	for _, site := range recent {
+		byDomain[site.Domain] = site
+	}
+	for _, row := range rows {
+		domain, err := CanonicalSite(row.Domain)
+		if err != nil {
+			continue
+		}
+		site := byDomain[domain]
+		site.Domain = domain
+		site.CookieCount += row.CookieCount
+		byDomain[domain] = site
+	}
+	result := make([]Site, 0, len(byDomain))
+	for _, site := range byDomain {
+		if site.CookieCount > 0 {
+			result = append(result, site)
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Visits != result[j].Visits {
+			return result[i].Visits > result[j].Visits
+		}
+		if !result[i].LastVisited.Equal(result[j].LastVisited) {
+			return result[i].LastVisited.After(result[j].LastVisited)
+		}
+		return result[i].Domain < result[j].Domain
+	})
 	return result, nil
 }
 
@@ -461,20 +486,22 @@ func copyFileBounded(ctx context.Context, source, destination string, limit int6
 
 var errFileGrew = errors.New("file grew while being copied")
 
-func selectedCookieClause(sites []string, hasWhere bool) string {
+func selectedCookieFilter(sites []string, hasWhere bool) (string, string) {
 	if len(sites) == 0 {
-		return ""
+		return "", ""
 	}
-	predicates := make([]string, 0, len(sites))
+	values := make([]string, 0, len(sites))
 	for _, site := range sites {
 		site = strings.TrimPrefix(strings.ToLower(site), ".")
-		predicates = append(predicates, "(host_key = "+sqliteLiteral(site)+" OR host_key = "+sqliteLiteral("."+site)+" OR host_key LIKE "+sqliteLiteral("%."+site)+")")
+		values = append(values, "("+sqliteLiteral(site)+")")
 	}
 	prefix := " WHERE "
 	if hasWhere {
 		prefix = " AND "
 	}
-	return prefix + "(" + strings.Join(predicates, " OR ") + ")"
+	cte := "WITH selected_sites(site) AS (VALUES " + strings.Join(values, ",") + ") "
+	predicate := prefix + "EXISTS (SELECT 1 FROM selected_sites WHERE host_key = site OR host_key = '.' || site OR host_key LIKE '%.' || site)"
+	return cte, predicate
 }
 
 func sqliteLiteral(value string) string {
@@ -540,6 +567,9 @@ func CanonicalSite(value string) (string, error) {
 }
 
 func matchesAnySite(cookieDomain string, sites []string) bool {
+	if len(sites) == 0 {
+		return true
+	}
 	for _, site := range sites {
 		if domainMatchesSite(cookieDomain, site) {
 			return true

--- a/internal/browserimport/chromium_test.go
+++ b/internal/browserimport/chromium_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -207,13 +208,7 @@ INSERT INTO cookies VALUES ('.google.com', '/', 'parent', 'selected', X'', 0, 1,
 	assert.Equal(t, "parent", cookies[0].Name)
 }
 
-func TestSelectedCookieClauseEscapesInput(t *testing.T) {
-	clause := selectedCookieClause([]string{"example.com' OR 1=1 --"}, false)
-	assert.Contains(t, clause, "example.com'' or 1=1 --")
-	assert.NotContains(t, clause, "example.com' OR 1=1 --'")
-}
-
-func TestCountCookiesForSitesDoesNotDecryptValues(t *testing.T) {
+func TestExportCookiesWithNoSiteFilterImportsAllEligibleCookies(t *testing.T) {
 	profile := sqliteProfileFixture(t)
 	database := filepath.Join(profile.Path, "Network", "Cookies")
 	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
@@ -222,13 +217,69 @@ CREATE TABLE cookies (
   host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
   expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER
 );
-INSERT INTO cookies VALUES ('.google.com', '/', 'encrypted', '', X'DEADBEEF', 0, 1, 1, 1);
+INSERT INTO cookies VALUES
+  ('.github.com', '/', 'github', 'one', X'', 0, 1, 1, 1),
+  ('.google.com', '/', 'google', 'two', X'', 0, 1, 1, 1),
+  ('localhost', '/', 'local-only', 'skip', X'', 0, 1, 1, 1);
 `)
 
-	sites, err := CountCookiesForSites(t.Context(), profile, []Site{{Domain: "google.com"}, {Domain: "github.com"}})
+	cookies, err := ExportCookies(t.Context(), profile, nil)
 	require.NoError(t, err)
-	assert.Equal(t, 1, sites[0].CookieCount)
-	assert.Zero(t, sites[1].CookieCount)
+	require.Len(t, cookies, 2)
+	assert.Equal(t, []string{"github", "google"}, []string{cookies[0].Name, cookies[1].Name})
+}
+
+func TestSelectedCookieFilterEscapesInput(t *testing.T) {
+	cte, clause := selectedCookieFilter([]string{"example.com' OR 1=1 --"}, false)
+	assert.Contains(t, cte, "example.com'' or 1=1 --")
+	assert.NotContains(t, cte, "example.com' OR 1=1 --'")
+	assert.Contains(t, clause, "EXISTS")
+}
+
+func TestExportCookiesSupportsLargeCustomSelection(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "Network", "Cookies")
+	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
+	runSQLite(t, database, `
+CREATE TABLE cookies (
+  host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+  expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER
+);
+INSERT INTO cookies VALUES ('.site-1999.com', '/', 'selected', 'yes', X'', 0, 1, 1, 1);
+`)
+	sites := make([]string, 2000)
+	for i := range sites {
+		sites[i] = fmt.Sprintf("site-%d.com", i)
+	}
+
+	cookies, err := ExportCookies(t.Context(), profile, sites)
+	require.NoError(t, err)
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "selected", cookies[0].Name)
+}
+
+func TestCookieSitesFindsEveryImportableDomainWithoutDecryptingValues(t *testing.T) {
+	profile := sqliteProfileFixture(t)
+	database := filepath.Join(profile.Path, "Network", "Cookies")
+	require.NoError(t, os.MkdirAll(filepath.Dir(database), 0o755))
+	runSQLite(t, database, `
+CREATE TABLE cookies (
+  host_key TEXT, path TEXT, name TEXT, value TEXT, encrypted_value BLOB,
+  expires_utc INTEGER, is_httponly INTEGER, is_secure INTEGER, samesite INTEGER,
+  top_frame_site_key TEXT
+);
+INSERT INTO cookies VALUES
+  ('.github.com', '/', 'one', '', X'DEADBEEF', 0, 1, 1, 1, ''),
+  ('api.github.com', '/', 'two', '', X'DEADBEEF', 0, 1, 1, 1, ''),
+  ('.older-site.com', '/', 'three', '', X'DEADBEEF', 0, 1, 1, 1, ''),
+  ('.partitioned.com', '/', 'skip', '', X'DEADBEEF', 0, 1, 1, 1, 'https://top.example');
+`)
+
+	sites, err := CookieSites(t.Context(), profile, []Site{{Domain: "github.com", Visits: 42}})
+	require.NoError(t, err)
+	require.Len(t, sites, 2)
+	assert.Equal(t, Site{Domain: "github.com", Visits: 42, CookieCount: 2}, sites[0])
+	assert.Equal(t, Site{Domain: "older-site.com", CookieCount: 1}, sites[1])
 }
 
 func writeBrowserFixture(t *testing.T, home, rootSuffix, directory, name string) {

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -224,7 +224,7 @@ func macOSAppleScript(executable string) string {
 	return `on «event GURLGURL» incomingURL
 set kernelExecutable to "` + appleScriptString(executable) + `"
 set commandText to quoted form of kernelExecutable & " connector open " & quoted form of incomingURL
-set scriptPath to «event sysoexec» "/usr/bin/mktemp /tmp/kernel-connector.XXXXXX.command"
+set scriptPath to «event sysoexec» "/usr/bin/mktemp /tmp/kernel-connector.XXXXXX"
 set scriptFile to «event rdwropen» POSIX file scriptPath with «class perm»
 «event rdwrwrit» "#!/bin/zsh" & linefeed & "rm -f " & quoted form of scriptPath & linefeed & "if [[ ! -x " & quoted form of kernelExecutable & " ]]; then echo 'Kernel CLI was removed. Reinstall it with: brew install kernel/tap/kernel'; read -k 1 '?Press any key to close'; exit 1; fi" & linefeed & "exec /bin/zsh -lic " & quoted form of commandText & linefeed given «class refn»:scriptFile
 «event rdwrclos» scriptFile

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -1,0 +1,248 @@
+// Package connector owns the small operating-system bridge between a
+// kernel:// browser deep link and the Kernel CLI.
+package connector
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	Scheme        = "kernel"
+	ImportHost    = "browser-import"
+	maxDeepLink   = 2048
+	bundleID      = "com.onkernel.cli.connector"
+	connectorName = "Kernel Connector.app"
+)
+
+var projectIDPattern = regexp.MustCompile(`^[a-z0-9]{24}$`)
+
+// BrowserImportLink is the trusted, non-secret input carried by a dashboard
+// deep link. The CLI still authenticates and authorizes the project itself.
+type BrowserImportLink struct {
+	ProjectID string
+}
+
+// ParseBrowserImportLink validates a Kernel browser-import deep link.
+func ParseBrowserImportLink(raw string) (BrowserImportLink, error) {
+	if raw == "" || len(raw) > maxDeepLink || strings.TrimSpace(raw) != raw {
+		return BrowserImportLink{}, errors.New("invalid Kernel browser import link")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != Scheme || parsed.Host != ImportHost || (parsed.Path != "" && parsed.Path != "/") || parsed.User != nil || parsed.Fragment != "" || parsed.Opaque != "" {
+		return BrowserImportLink{}, errors.New("invalid Kernel browser import link")
+	}
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil || len(query) != 1 || len(query["project_id"]) != 1 {
+		return BrowserImportLink{}, errors.New("invalid Kernel browser import link")
+	}
+	projectID := query.Get("project_id")
+	if !projectIDPattern.MatchString(projectID) {
+		return BrowserImportLink{}, errors.New("invalid Kernel project ID")
+	}
+	return BrowserImportLink{ProjectID: projectID}, nil
+}
+
+// URL returns the canonical browser-import deep link for a project.
+func URL(projectID string) (string, error) {
+	if !projectIDPattern.MatchString(projectID) {
+		return "", errors.New("invalid Kernel project ID")
+	}
+	query := url.Values{"project_id": []string{projectID}}
+	return Scheme + "://" + ImportHost + "?" + query.Encode(), nil
+}
+
+type commandRunner func(context.Context, string, ...string) error
+
+// Install registers the connector for the current user without downloading
+// another executable. The macOS app delegates back to this Kernel binary.
+func Install(ctx context.Context, home, executable string) (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", fmt.Errorf("Kernel Connector installation is not yet supported on %s", runtime.GOOS)
+	}
+	return installMacOS(ctx, home, executable, runCommand)
+}
+
+func installMacOS(ctx context.Context, home, executable string, run commandRunner) (string, error) {
+	if home == "" || !filepath.IsAbs(home) || executable == "" || !filepath.IsAbs(executable) {
+		return "", errors.New("Kernel Connector requires absolute home and executable paths")
+	}
+	applications := filepath.Join(home, "Applications")
+	if err := os.MkdirAll(applications, 0o755); err != nil {
+		return "", fmt.Errorf("create Applications directory: %w", err)
+	}
+	temporaryRoot, err := os.MkdirTemp(applications, ".kernel-connector-")
+	if err != nil {
+		return "", fmt.Errorf("prepare Kernel Connector: %w", err)
+	}
+	removeTemporaryRoot := true
+	defer func() {
+		if removeTemporaryRoot {
+			_ = os.RemoveAll(temporaryRoot)
+		}
+	}()
+	temporaryApp := filepath.Join(temporaryRoot, connectorName)
+	if err := run(ctx, "/usr/bin/osacompile", "-o", temporaryApp, "-e", macOSAppleScript(executable)); err != nil {
+		return "", fmt.Errorf("build Kernel Connector app: %w", err)
+	}
+	plist := filepath.Join(temporaryApp, "Contents", "Info.plist")
+	commands := [][]string{
+		{"-replace", "CFBundleIdentifier", "-string", bundleID, plist},
+		{"-insert", "LSUIElement", "-bool", "YES", plist},
+		{"-insert", "CFBundleURLTypes", "-json", `[{"CFBundleURLName":"Kernel Browser Import","CFBundleURLSchemes":["kernel"]}]`, plist},
+	}
+	for _, args := range commands {
+		if err := run(ctx, "/usr/bin/plutil", args...); err != nil {
+			return "", fmt.Errorf("configure Kernel Connector app: %w", err)
+		}
+	}
+	if err := run(ctx, "/usr/bin/codesign", "--force", "--sign", "-", temporaryApp); err != nil {
+		return "", fmt.Errorf("sign Kernel Connector app: %w", err)
+	}
+	if err := run(ctx, "/usr/bin/codesign", "--verify", "--strict", temporaryApp); err != nil {
+		return "", fmt.Errorf("verify Kernel Connector app: %w", err)
+	}
+	destination := filepath.Join(applications, connectorName)
+	backup := filepath.Join(temporaryRoot, "previous.app")
+	if _, err := os.Lstat(destination); err == nil {
+		owned, ownershipErr := isKernelConnector(destination)
+		if ownershipErr != nil {
+			return "", fmt.Errorf("inspect existing Kernel Connector app: %w", ownershipErr)
+		}
+		if !owned {
+			return "", fmt.Errorf("refusing to replace app not owned by Kernel: %s", destination)
+		}
+		if err := os.Rename(destination, backup); err != nil {
+			return "", fmt.Errorf("replace Kernel Connector app: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if err := os.Rename(temporaryApp, destination); err != nil {
+		if _, backupErr := os.Lstat(backup); backupErr == nil {
+			if restoreErr := os.Rename(backup, destination); restoreErr != nil {
+				removeTemporaryRoot = false
+				return "", fmt.Errorf("install Kernel Connector app: %w; restoring previous app failed: %v; backup preserved at %s", err, restoreErr, backup)
+			}
+		}
+		return "", fmt.Errorf("install Kernel Connector app: %w", err)
+	}
+	register := "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+	if err := run(ctx, register, "-f", destination); err != nil {
+		if removeErr := os.RemoveAll(destination); removeErr != nil {
+			removeTemporaryRoot = false
+			return "", fmt.Errorf("register kernel:// handler: %w; remove failed installation: %v; previous app preserved at %s", err, removeErr, backup)
+		}
+		if _, backupErr := os.Lstat(backup); backupErr == nil {
+			if restoreErr := os.Rename(backup, destination); restoreErr != nil {
+				removeTemporaryRoot = false
+				return "", fmt.Errorf("register kernel:// handler: %w; restoring previous app failed: %v; backup preserved at %s", err, restoreErr, backup)
+			}
+		}
+		return "", fmt.Errorf("register kernel:// handler: %w", err)
+	}
+	return destination, nil
+}
+
+func isKernelConnector(app string) (bool, error) {
+	info, err := os.Lstat(app)
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	plist, err := os.Open(filepath.Join(app, "Contents", "Info.plist"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer plist.Close()
+	const maxPlistSize = 1 << 20
+	contents, err := io.ReadAll(io.LimitReader(plist, maxPlistSize+1))
+	if err != nil {
+		return false, err
+	}
+	if len(contents) > maxPlistSize {
+		return false, errors.New("existing app Info.plist is too large")
+	}
+	identifier, err := bundleIdentifier(contents)
+	if err != nil {
+		return false, err
+	}
+	return identifier == bundleID, nil
+}
+
+func bundleIdentifier(contents []byte) (string, error) {
+	decoder := xml.NewDecoder(strings.NewReader(string(contents)))
+	wantValue := false
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("parse Info.plist: %w", err)
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local == "key" {
+			var key string
+			if err := decoder.DecodeElement(&key, &start); err != nil {
+				return "", fmt.Errorf("parse Info.plist key: %w", err)
+			}
+			wantValue = key == "CFBundleIdentifier"
+			continue
+		}
+		if wantValue && start.Name.Local == "string" {
+			var value string
+			if err := decoder.DecodeElement(&value, &start); err != nil {
+				return "", fmt.Errorf("parse CFBundleIdentifier: %w", err)
+			}
+			return value, nil
+		}
+		wantValue = false
+	}
+	return "", errors.New("existing app has no CFBundleIdentifier")
+}
+
+func macOSAppleScript(executable string) string {
+	return `on «event GURLGURL» incomingURL
+set kernelExecutable to "` + appleScriptString(executable) + `"
+set commandText to quoted form of kernelExecutable & " connector open " & quoted form of incomingURL
+set scriptPath to «event sysoexec» "/usr/bin/mktemp /tmp/kernel-connector.XXXXXX.command"
+set scriptFile to «event rdwropen» POSIX file scriptPath with «class perm»
+«event rdwrwrit» "#!/bin/zsh" & linefeed & "rm -f " & quoted form of scriptPath & linefeed & "if [[ ! -x " & quoted form of kernelExecutable & " ]]; then echo 'Kernel CLI was removed. Reinstall it with: brew install kernel/tap/kernel'; read -k 1 '?Press any key to close'; exit 1; fi" & linefeed & "exec /bin/zsh -lic " & quoted form of commandText & linefeed given «class refn»:scriptFile
+«event rdwrclos» scriptFile
+«event sysoexec» "/bin/chmod 700 " & quoted form of scriptPath
+«event sysoexec» "/usr/bin/open -a Terminal " & quoted form of scriptPath
+end «event GURLGURL»`
+}
+
+func appleScriptString(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	return strings.ReplaceAll(value, `"`, `\"`)
+}
+
+func runCommand(ctx context.Context, name string, args ...string) error {
+	command := exec.CommandContext(ctx, name, args...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}

--- a/internal/connector/connector_darwin_test.go
+++ b/internal/connector/connector_darwin_test.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package connector
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMacOSAppleScriptCompiles(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Kernel Connector.app")
+	command := exec.Command("/usr/bin/osacompile", "-o", app, "-e", macOSAppleScript("/opt/homebrew/bin/kernel"))
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+}

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -133,6 +133,8 @@ func TestMacOSAppleScriptShellQuotesURLAtRuntime(t *testing.T) {
 	assert.Contains(t, script, `" connector open "`)
 	assert.Contains(t, script, `/usr/bin/open -a Terminal`)
 	assert.Contains(t, script, `/bin/zsh -lic`)
+	assert.Contains(t, script, `/usr/bin/mktemp /tmp/kernel-connector.XXXXXX`)
+	assert.NotContains(t, script, `XXXXXX.command`)
 	assert.Contains(t, script, `Kernel CLI was removed`)
 	assert.Contains(t, script, `«event GURLGURL»`)
 	assert.NotContains(t, script, `tell application "Terminal"`)

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -1,0 +1,157 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testProjectID = "ibdzi0e8019dpsonqwixsbfe"
+
+func testPlist(identifier string) []byte {
+	return []byte(`<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>CFBundleIdentifier</key><string>` + identifier + `</string></dict></plist>`)
+}
+
+func TestParseBrowserImportLink(t *testing.T) {
+	t.Parallel()
+	link, err := ParseBrowserImportLink("kernel://browser-import?project_id=" + testProjectID)
+	require.NoError(t, err)
+	assert.Equal(t, testProjectID, link.ProjectID)
+}
+
+func TestParseBrowserImportLinkRejectsUntrustedShapes(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"https://browser-import?project_id=" + testProjectID,
+		"kernel://evil?project_id=" + testProjectID,
+		"kernel://browser-import/path?project_id=" + testProjectID,
+		"kernel://browser-import?project_id=" + testProjectID + "&next=https://evil.test",
+		"kernel://browser-import?project_id=" + testProjectID + "&project_id=" + testProjectID,
+		"kernel://browser-import?project_id=not-a-project",
+		"kernel://browser-import?project_id=" + testProjectID + "#fragment",
+	} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseBrowserImportLink(raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestURLRoundTrip(t *testing.T) {
+	t.Parallel()
+	raw, err := URL(testProjectID)
+	require.NoError(t, err)
+	link, err := ParseBrowserImportLink(raw)
+	require.NoError(t, err)
+	assert.Equal(t, testProjectID, link.ProjectID)
+}
+
+func TestInstallMacOSBuildsAndRegistersUserApp(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(home, "bin", "kernel")
+	var calls [][]string
+	runner := func(_ context.Context, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		if name == "/usr/bin/osacompile" {
+			app := args[1]
+			require.NoError(t, os.MkdirAll(filepath.Join(app, "Contents"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(app, "Contents", "Info.plist"), []byte("plist"), 0o600))
+		}
+		return nil
+	}
+
+	installed, err := installMacOS(t.Context(), home, executable, runner)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "Applications", connectorName), installed)
+	require.NotEmpty(t, calls)
+	assert.Equal(t, "/usr/bin/osacompile", calls[0][0])
+	assert.Contains(t, calls[0][4], executable)
+	last := calls[len(calls)-1]
+	assert.Contains(t, last[0], "lsregister")
+	assert.Equal(t, []string{"-f", installed}, last[1:])
+}
+
+func TestInstallMacOSRefusesToReplaceForeignApp(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(home, "bin", "kernel")
+	destination := filepath.Join(home, "Applications", connectorName)
+	require.NoError(t, os.MkdirAll(filepath.Join(destination, "Contents"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(destination, "Contents", "Info.plist"), testPlist("example.foreign."+bundleID), 0o600))
+	runner := func(_ context.Context, name string, args ...string) error {
+		if name == "/usr/bin/osacompile" {
+			app := args[1]
+			require.NoError(t, os.MkdirAll(filepath.Join(app, "Contents"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(app, "Contents", "Info.plist"), testPlist(bundleID), 0o600))
+		}
+		return nil
+	}
+
+	_, err := installMacOS(t.Context(), home, executable, runner)
+	require.ErrorContains(t, err, "not owned by Kernel")
+	contents, readErr := os.ReadFile(filepath.Join(destination, "Contents", "Info.plist"))
+	require.NoError(t, readErr)
+	assert.Equal(t, testPlist("example.foreign."+bundleID), contents)
+}
+
+func TestInstallMacOSRestoresPreviousAppWhenRegistrationFails(t *testing.T) {
+	home := t.TempDir()
+	executable := filepath.Join(home, "bin", "kernel")
+	destination := filepath.Join(home, "Applications", connectorName)
+	require.NoError(t, os.MkdirAll(filepath.Join(destination, "Contents"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(destination, "Contents", "Info.plist"), testPlist(bundleID), 0o600))
+	runner := func(_ context.Context, name string, args ...string) error {
+		if name == "/usr/bin/osacompile" {
+			app := args[1]
+			require.NoError(t, os.MkdirAll(filepath.Join(app, "Contents"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(app, "Contents", "Info.plist"), testPlist(bundleID), 0o600))
+		}
+		if strings.Contains(name, "lsregister") {
+			return errors.New("registration failed")
+		}
+		return nil
+	}
+
+	_, err := installMacOS(t.Context(), home, executable, runner)
+	require.ErrorContains(t, err, "register kernel:// handler")
+	contents, readErr := os.ReadFile(filepath.Join(destination, "Contents", "Info.plist"))
+	require.NoError(t, readErr)
+	assert.Equal(t, testPlist(bundleID), contents)
+}
+
+func TestMacOSAppleScriptShellQuotesURLAtRuntime(t *testing.T) {
+	t.Parallel()
+	script := macOSAppleScript(`/opt/homebrew/bin/kernel`)
+	assert.Contains(t, script, `quoted form of incomingURL`)
+	assert.Contains(t, script, `" connector open "`)
+	assert.Contains(t, script, `/usr/bin/open -a Terminal`)
+	assert.Contains(t, script, `/bin/zsh -lic`)
+	assert.Contains(t, script, `Kernel CLI was removed`)
+	assert.Contains(t, script, `«event GURLGURL»`)
+	assert.NotContains(t, script, `tell application "Terminal"`)
+	assert.NotContains(t, script, "project_id=")
+
+	escaped := macOSAppleScript(`/Applications/a\"b/kernel`)
+	assert.True(t, strings.Contains(escaped, `a\\\"b`))
+}
+
+func TestBundleIdentifierRequiresExactValidPlistValue(t *testing.T) {
+	t.Parallel()
+	identifier, err := bundleIdentifier(testPlist(bundleID))
+	require.NoError(t, err)
+	assert.Equal(t, bundleID, identifier)
+
+	identifier, err = bundleIdentifier([]byte(`<?xml version="1.0"?><plist><dict><key>Comment</key><string>` + bundleID + `</string><key>CFBundleIdentifier</key><string>example.foreign</string></dict></plist>`))
+	require.NoError(t, err)
+	assert.Equal(t, "example.foreign", identifier)
+
+	_, err = bundleIdentifier([]byte("not a plist"))
+	require.Error(t, err)
+}

--- a/internal/passwordmanager/bitwarden.go
+++ b/internal/passwordmanager/bitwarden.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type bitwardenProvider struct {
@@ -45,14 +47,17 @@ func (p *bitwardenProvider) Candidates(ctx context.Context, sites []string) ([]C
 	if err != nil {
 		return nil, err
 	}
+	results, err := fetchBitwardenCandidateSites(ctx, sites, func(ctx context.Context, site string) ([]bitwardenCandidateItem, error) {
+		return p.candidateItems(ctx, environment, site)
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	seen := make(map[string]struct{})
 	candidates := make([]Candidate, 0)
-	for _, site := range sites {
-		items, err := p.candidateItems(ctx, environment, site)
-		if err != nil {
-			return nil, fmt.Errorf("find Bitwarden logins for %s: %w", site, err)
-		}
-		for _, item := range items {
+	for index, site := range sites {
+		for _, item := range results[index] {
 			if item.Login == nil || item.OrganizationID != "" {
 				continue
 			}
@@ -65,6 +70,28 @@ func (p *bitwardenProvider) Candidates(ctx context.Context, sites []string) ([]C
 		}
 	}
 	return candidates, nil
+}
+
+func fetchBitwardenCandidateSites(ctx context.Context, sites []string, fetch func(context.Context, string) ([]bitwardenCandidateItem, error)) ([][]bitwardenCandidateItem, error) {
+	results := make([][]bitwardenCandidateItem, len(sites))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(min(4, len(sites)))
+	for index, site := range sites {
+		index, site := index, site
+		group.Go(func() error {
+			items, err := fetch(groupCtx, site)
+			if err != nil {
+				return fmt.Errorf("find Bitwarden logins for %s: %w", site, err)
+			}
+			results[index] = items
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }
 
 func (p *bitwardenProvider) candidateItems(ctx context.Context, environment map[string]string, site string) ([]bitwardenCandidateItem, error) {

--- a/internal/passwordmanager/passwordmanager_test.go
+++ b/internal/passwordmanager/passwordmanager_test.go
@@ -1,10 +1,13 @@
 package passwordmanager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,6 +96,79 @@ esac
 	require.NoError(t, err)
 	assert.False(t, required)
 	assert.Empty(t, os.Getenv("BW_SESSION"))
+}
+
+func TestBitwardenCandidateDiscoveryDoesNotSync(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "commands")
+	path := filepath.Join(t.TempDir(), "bw")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$BW_TEST_LOG"
+case "$1" in
+  status) printf '{"status":"unlocked"}' ;;
+  list) printf '[]' ;;
+  sync) exit 99 ;;
+  *) exit 1 ;;
+esac
+`
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o700))
+	t.Setenv("BW_TEST_LOG", logPath)
+	provider := &bitwardenProvider{path: path}
+
+	candidates, err := provider.Candidates(context.Background(), []string{"github.com"})
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+	commands, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(commands), "sync")
+	assert.Contains(t, string(commands), "list items --url github.com")
+}
+
+func TestBitwardenCandidateQueriesAreBoundedOrderedAndCanceled(t *testing.T) {
+	sites := []string{"one.com", "two.com", "three.com", "four.com", "five.com", "six.com"}
+	var active, peak atomic.Int32
+	results, err := fetchBitwardenCandidateSites(t.Context(), sites, func(ctx context.Context, site string) ([]bitwardenCandidateItem, error) {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		time.Sleep(time.Duration(len(sites)-stringIndex(sites, site)) * time.Millisecond)
+		return []bitwardenCandidateItem{{ID: site}}, nil
+	})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, peak.Load(), int32(4))
+	for index, site := range sites {
+		assert.Equal(t, site, results[index][0].ID)
+	}
+
+	canceled := make(chan struct{}, 1)
+	_, err = fetchBitwardenCandidateSites(t.Context(), []string{"fail", "slow"}, func(ctx context.Context, site string) ([]bitwardenCandidateItem, error) {
+		if site == "fail" {
+			time.Sleep(10 * time.Millisecond)
+			return nil, assert.AnError
+		}
+		<-ctx.Done()
+		canceled <- struct{}{}
+		return nil, ctx.Err()
+	})
+	require.Error(t, err)
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("sibling query was not canceled")
+	}
+}
+
+func stringIndex(values []string, target string) int {
+	for index, value := range values {
+		if value == target {
+			return index
+		}
+	}
+	return -1
 }
 
 func TestOnePasswordLongSummaryCanMatchWithoutItemReveal(t *testing.T) {

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,10 @@ import (
 	"github.com/kernel/kernel-go-sdk/option"
 	"github.com/pterm/pterm"
 )
+
+// ErrAuthenticationRequired reports credentials that can be repaired by an
+// interactive OAuth login.
+var ErrAuthenticationRequired = errors.New("authentication required")
 
 // GetAuthenticatedClient returns a Kernel client with appropriate authentication
 func GetAuthenticatedClient(opts ...option.RequestOption) (*kernel.Client, error) {
@@ -32,7 +37,10 @@ func BearerToken(ctx context.Context) (string, error) {
 
 	tokens, err := LoadTokens()
 	if err != nil {
-		return "", fmt.Errorf("no authentication available. Please run 'kernel login' or set KERNEL_API_KEY environment variable")
+		if !errors.Is(err, ErrNoStoredCredentials) {
+			return "", err
+		}
+		return "", fmt.Errorf("%w: run 'kernel login' or set KERNEL_API_KEY", ErrAuthenticationRequired)
 	}
 	if !tokens.IsExpired() || tokens.RefreshToken == "" {
 		return tokens.AccessToken, nil
@@ -42,12 +50,20 @@ func BearerToken(ctx context.Context) (string, error) {
 	refreshedTokens, refreshErr := RefreshTokens(ctx, tokens)
 	if refreshErr != nil {
 		pterm.Warning.Printf("Failed to refresh tokens: %v\n", refreshErr)
-		pterm.Info.Println("Please run 'kernel login' to re-authenticate")
-		return "", fmt.Errorf("expired credentials, please re-authenticate: %w", refreshErr)
+		if refreshRequiresLogin(refreshErr) {
+			pterm.Info.Println("Please run 'kernel login' to re-authenticate")
+			return "", fmt.Errorf("%w: expired credentials: %v", ErrAuthenticationRequired, refreshErr)
+		}
+		return "", fmt.Errorf("refresh credentials: %w", refreshErr)
 	}
 	if saveErr := SaveTokens(refreshedTokens); saveErr != nil {
 		pterm.Warning.Printf("Failed to save credentials: %v\n", saveErr)
 	}
 	pterm.Debug.Println("Successfully refreshed access token")
 	return refreshedTokens.AccessToken, nil
+}
+
+func refreshRequiresLogin(err error) bool {
+	var rejected *TokenRefreshError
+	return errors.As(err, &rejected) && (rejected.StatusCode == 400 || rejected.StatusCode == 401)
 }

--- a/pkg/auth/client_test.go
+++ b/pkg/auth/client_test.go
@@ -1,0 +1,16 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefreshRequiresLoginOnlyForRejectedCredentials(t *testing.T) {
+	assert.True(t, refreshRequiresLogin(&TokenRefreshError{StatusCode: http.StatusBadRequest}))
+	assert.True(t, refreshRequiresLogin(&TokenRefreshError{StatusCode: http.StatusUnauthorized}))
+	assert.False(t, refreshRequiresLogin(&TokenRefreshError{StatusCode: http.StatusInternalServerError}))
+	assert.False(t, refreshRequiresLogin(errors.New("network unavailable")))
+}

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -79,6 +79,16 @@ type AuthResult struct {
 	ProjectID   string `json:"project_id,omitempty"`
 }
 
+// TokenRefreshError reports an OAuth refresh response rejected by the auth
+// server. Transport and decoding failures remain their original error types.
+type TokenRefreshError struct {
+	StatusCode int
+}
+
+func (e *TokenRefreshError) Error() string {
+	return fmt.Sprintf("refresh request failed with status %d", e.StatusCode)
+}
+
 // CurrentAuthBaseURL returns the OAuth server base URL for new login flows.
 func CurrentAuthBaseURL() string {
 	return authBaseURLFromEnv()
@@ -392,8 +402,8 @@ func RefreshTokens(ctx context.Context, tokens *TokenStorage) (*TokenStorage, er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("refresh request failed with status %d: %s", resp.StatusCode, string(body))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &TokenRefreshError{StatusCode: resp.StatusCode}
 	}
 
 	// Parse the response

--- a/pkg/auth/storage.go
+++ b/pkg/auth/storage.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,10 @@ const (
 	KeyringService = "kernel-cli"
 	KeyringUser    = "oauth-tokens"
 )
+
+// ErrNoStoredCredentials reports that neither keychain nor file credentials
+// exist. Callers may offer login for this error without hiding storage faults.
+var ErrNoStoredCredentials = errors.New("no stored credentials found")
 
 // TokenStorage represents stored authentication tokens
 type TokenStorage struct {
@@ -51,11 +56,22 @@ func SaveTokens(tokens *TokenStorage) error {
 
 // LoadTokens retrieves authentication tokens from secure storage
 func LoadTokens() (*TokenStorage, error) {
+	return loadTokens(keyring.Get)
+}
+
+func loadTokens(get func(string, string) (string, error)) (*TokenStorage, error) {
 	// Try to load from OS keychain first
-	data, err := keyring.Get(KeyringService, KeyringUser)
+	data, err := get(KeyringService, KeyringUser)
 	if err != nil {
 		// Fallback to file storage
-		return loadTokensFromFile()
+		tokens, fileErr := loadTokensFromFile()
+		if fileErr == nil {
+			return tokens, nil
+		}
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil, fileErr
+		}
+		return nil, fmt.Errorf("failed to load tokens from keychain: %w", err)
 	}
 
 	var tokens TokenStorage
@@ -126,7 +142,7 @@ func loadTokensFromFile() (*TokenStorage, error) {
 	data, err := os.ReadFile(tokenFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("no stored credentials found")
+			return nil, ErrNoStoredCredentials
 		}
 		return nil, fmt.Errorf("failed to read tokens from file: %w", err)
 	}

--- a/pkg/auth/storage_test.go
+++ b/pkg/auth/storage_test.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTokensFromFileReportsMissingCredentials(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := loadTokensFromFile()
+
+	require.ErrorIs(t, err, ErrNoStoredCredentials)
+}
+
+func TestLoadTokensPreservesUnexpectedKeyringFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	want := errors.New("keychain access denied")
+
+	_, err := loadTokens(func(string, string) (string, error) { return "", want })
+
+	require.ErrorIs(t, err, want)
+	require.NotErrorIs(t, err, ErrNoStoredCredentials)
+}

--- a/pkg/interactive/interactive.go
+++ b/pkg/interactive/interactive.go
@@ -171,14 +171,30 @@ func newConfirmPrinter(promptText string, defaultValue bool) *pterm.InteractiveC
 // When the Prompter cannot prompt it fails fast with
 // ErrInputRequired(what, hint) instead.
 func (p Prompter) Select(what, hint, promptText string, options []string) (string, error) {
+	defaultOption := ""
+	if len(options) > 0 {
+		defaultOption = options[0]
+	}
+	return p.SelectDefault(what, hint, promptText, options, defaultOption)
+}
+
+// SelectDefault shows a select prompt with the requested option highlighted.
+func (p Prompter) SelectDefault(what, hint, promptText string, options []string, defaultOption string) (string, error) {
 	if !p.CanPrompt() {
 		return "", ErrInputRequired(what, hint)
 	}
-	return pterm.DefaultInteractiveSelect.
+	return newSelectPrinter(promptText, options, defaultOption).Show()
+}
+
+func newSelectPrinter(promptText string, options []string, defaultOption string) *pterm.InteractiveSelectPrinter {
+	printer := pterm.DefaultInteractiveSelect.
 		WithOptions(options).
 		WithDefaultText(promptText).
-		WithMaxHeight(len(options)).
-		Show()
+		WithMaxHeight(min(len(options), 12))
+	if defaultOption != "" {
+		printer = printer.WithDefaultOption(defaultOption)
+	}
+	return printer
 }
 
 // MultiSelect shows a checkbox menu and returns the selected options.

--- a/pkg/interactive/interactive_test.go
+++ b/pkg/interactive/interactive_test.go
@@ -121,6 +121,24 @@ func TestMultiSelectUsesConventionalKeys(t *testing.T) {
 	assert.Equal(t, keys.Enter, printer.KeyConfirm)
 }
 
+func TestSelectDefaultsToFirstOption(t *testing.T) {
+	t.Parallel()
+	options := make([]string, 2000)
+	options[0] = "Done"
+	printer := newSelectPrinter("Remove a website, or continue", options, options[0])
+
+	assert.Equal(t, "Done", printer.DefaultOption)
+	assert.Equal(t, 12, printer.MaxHeight)
+}
+
+func TestSelectCanHighlightARequestedOption(t *testing.T) {
+	t.Parallel()
+	options := []string{"first", "chosen", "skip"}
+	printer := newSelectPrinter("Choose one", options, "chosen")
+
+	assert.Equal(t, "chosen", printer.DefaultOption)
+}
+
 func TestConfirmPrinterUsesRequestedDefault(t *testing.T) {
 	t.Parallel()
 	assert.False(t, newConfirmPrinter("Delete it?", false).DefaultValue)


### PR DESCRIPTION
## What

Add the macOS bridge that lets the Kernel dashboard open the existing local browser-import wizard with a `kernel://browser-import?project_id=...` link.

- adds `kernel connector install` to register a user-level `Kernel Connector.app`
- adds the hidden `kernel connector open` deep-link entrypoint
- validates the link and confirms the authenticated user can access the requested active project
- reuses `profiles import-local`; no second importer or downloaded helper is introduced
- installs the connector best-effort from the Homebrew formula on macOS

## Why

The previous dashboard handoff asked users to copy several terminal commands and manually carry a project ID. The connector turns that into one dashboard button while keeping sensitive browser and password-manager access inside the local CLI and its explicit terminal confirmations.

## How

The dashboard supplies only a non-secret project ID. The CLI remains responsible for authentication, authorization, browser discovery, cookie selection, password-manager approval, profile import, and Managed Auth provisioning.

The installed app is a tiny AppleScript URL handler that delegates to the stable Kernel CLI path through a login shell. Installation is user-scoped, verifies exact bundle ownership before replacement, signs the completed app, preserves the previous app if rollback fails, and registers it with Launch Services. No server-side intent or new API is required.

This is intentionally macOS-only for the MVP. Windows and Linux return an explicit unsupported-platform error until their protocol-handler packaging is implemented.

## Safety

- accepts only the exact `kernel://browser-import` route with one validated project ID
- authenticates locally and checks project access before import
- refuses to replace an app not owned by Kernel
- shell-quotes the executable and incoming URL
- keeps password-manager sessions process-local
- uses a unique BSD-compatible temporary launcher path and removes it on start

## Verification

- `go test ./internal/connector ./internal/browserimport ./internal/passwordmanager ./internal/agentskills ./pkg/auth ./pkg/interactive ./cmd`
- `go vet ./internal/connector ./internal/browserimport ./internal/passwordmanager ./internal/agentskills ./pkg/auth ./pkg/interactive ./cmd`
- Darwin smoke test compiles the emitted AppleScript with the real `/usr/bin/osacompile`
- real local connector installation completed and `/usr/bin/codesign --verify --strict` passed
- focused tests cover deep-link parsing, project authorization, authentication recovery, app ownership, rollback, and launcher generation

## Stack

Depends on #224, which depends on #223.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Registers a macOS protocol handler (AppleScript + Launch Services) and changes authentication recovery, cookie export, and password-manager/Managed Auth provisioning. Bugs here can affect local credential handling, project access, or OS-level URL dispatch.
> 
> **Overview**
> Lets the Kernel dashboard launch local browser import via a `kernel://browser-import?project_id=...` link, instead of copying CLI commands.
> 
> Adds `kernel connector install` (Homebrew post-install on macOS) which registers a user-scoped `Kernel Connector.app` URL handler that delegates to the stable CLI binary. Hidden `connector open` parses a tightly validated deep link, authenticates on demand, checks the project is active, and reuses `profiles import-local`. Wrong-account or invalid-API-key cases can recover with a prompted browser login (process-local `KERNEL_API_KEY` unset only).
> 
> Local import no longer caps at 5–10 recent sites: users can import **all cookies** or pick sites, and Managed Auth is quota-aware (org `max_auth_connections`), skips existing connections, and chooses logins per website. Cookie export can filter large site lists via a SQLite CTE; Bitwarden candidate lookup is bounded and concurrent. Auth now distinguishes missing credentials from storage/refresh failures so the connector can prompt login without hiding real errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91296d1de23804d5a3e5364bcbae56bcede86a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->