### PR TITLE
warn when a deploy sets a reserved env var (KERNEL-1620)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -110,6 +110,21 @@ func init() {
 	deployCmd.AddCommand(deployGithubCmd)
 }
 
+// reservedDeployEnvVars are set by the platform on every deployment; a
+// user-supplied value is overridden and ignored. Mirrors the reserved set in
+// the API's deploy activity.
+var reservedDeployEnvVars = []string{"KERNEL_API_KEY", "ENTRYPOINT_RELPATH"}
+
+// warnReservedEnvVars notifies the user when a supplied env var is reserved and
+// will be ignored, so a silently-dropped value doesn't surprise them later.
+func warnReservedEnvVars(envVars map[string]string) {
+	for _, k := range reservedDeployEnvVars {
+		if _, ok := envVars[k]; ok {
+			pterm.Warning.Printfln("%s is reserved by Kernel and will be ignored (Kernel sets it automatically). Use a different variable name if you need your own value.", k)
+		}
+	}
+}
+
 func runDeployGithub(cmd *cobra.Command, args []string) error {
 	client := getKernelClient(cmd)
 
@@ -150,6 +165,10 @@ func runDeployGithub(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid env variable format: %s (expected KEY=value)", kv)
 		}
 		envVars[parts[0]] = parts[1]
+	}
+
+	if output != "json" {
+		warnReservedEnvVars(envVars)
 	}
 
 	// Build the multipart request body directly for source-based deploy
@@ -310,6 +329,10 @@ func runDeploy(cmd *cobra.Command, args []string) (err error) {
 			return fmt.Errorf("invalid env variable format: %s (expected KEY=value)", kv)
 		}
 		envVars[parts[0]] = parts[1]
+	}
+
+	if output != "json" {
+		warnReservedEnvVars(envVars)
 	}
 
 	logger.Debug("deploying app", logger.Args("version", version, "force", force, "entrypoint", filepath.Base(resolvedEntrypoint)))


### PR DESCRIPTION
surfaces the silent `KERNEL_API_KEY` override to the user at deploy time.

right now if you set `KERNEL_API_KEY` via `--env`/`--env-file`, the platform overrides it with the per-deployment key and your value is silently dropped — no signal, and it's the reason behind KERNEL-1620 / a pylon thread. this prints a `pterm.Warning` (same convention as the existing "Requested --per-page N; capped to 100" warnings) when a reserved var is supplied, on both deploy paths (file/CLI + github source):

```
KERNEL_API_KEY is reserved by Kernel and will be ignored (Kernel sets it automatically). Use a different variable name if you need your own value.
```

- warn-only, no behavior change — the override itself is unchanged.
- covers `KERNEL_API_KEY` and `ENTRYPOINT_RELPATH`; guarded behind `output != "json"` so json output stays clean.
- server-side gets a `log.WarnContext` breadcrumb for the SDK/API deploy paths (separate kernel/kernel PR), and the deployment key lifecycle + reserved vars are now documented (kernel/docs #504).

did not go with respecting a user-supplied key — they can already pass their own under a non-reserved name and read it explicitly, so honoring `KERNEL_API_KEY` would just add ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX change with no deploy API or override logic modified; low risk aside from extra stderr warnings in interactive mode.
> 
> **Overview**
> Adds **deploy-time warnings** when `--env` / `--env-file` includes platform-reserved variables (`KERNEL_API_KEY`, `ENTRYPOINT_RELPATH`), which the backend overwrites and previously dropped without feedback.
> 
> Introduces `warnReservedEnvVars` in `cmd/deploy.go` (aligned with the API deploy activity’s reserved set) and invokes it after env merging on both **local/file deploy** and **GitHub source deploy**, using the same `pterm.Warning` style as other CLI caps. Warnings are **skipped when `-o json`** so machine output stays clean. Deploy behavior is unchanged—warn-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff437b4eebf903ac7434cfd8f8923145547ef1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->