### PR TITLE
Clarify press key input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,9 +478,11 @@ Destinations are the OTLP/HTTP endpoints sessions export to, managed per project
 
 - `kernel browsers computer press-key <id>` - Press one or more keys
 
-  - `--key <key>` - Key symbols to press (repeatable)
+  - `--key <key>` - One X11 keysym or chord, such as `Return`, `Ctrl+t`, or `Ctrl+minus` (repeatable)
   - `--duration <ms>` - Duration to hold keys down in ms (0=tap)
   - `--hold-key <key>` - Modifier keys to hold (repeatable)
+
+  Pass sequential or repeated key presses as separate `--key` values, for example `--key BackSpace --key BackSpace`. Use `computer type --text` to enter text instead of passing text to `press-key`.
 
 - `kernel browsers computer scroll <id>` - Scroll the mouse wheel
 

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -2879,7 +2879,7 @@ func init() {
 
 	// computer press-key
 	computerPressKey := &cobra.Command{Use: "press-key <id>", Short: "Press one or more keys", Args: cobra.ExactArgs(1), RunE: runBrowsersComputerPressKey}
-	computerPressKey.Flags().StringSlice("key", []string{}, "Key symbols to press (repeatable)")
+	computerPressKey.Flags().StringSlice("key", []string{}, "One X11 keysym or chord per value, e.g. Return, Ctrl+t, or Ctrl+minus (repeatable)")
 	_ = computerPressKey.MarkFlagRequired("key")
 	computerPressKey.Flags().Int64("duration", 0, "Duration to hold keys down in ms (0=tap)")
 	computerPressKey.Flags().StringSlice("hold-key", []string{}, "Modifier keys to hold (repeatable)")


### PR DESCRIPTION
## Summary
- document that each `--key` value accepts one X11 keysym or chord
- add canonical `Ctrl+minus` and repeated-key examples
- direct users to `computer type --text` for text input

## Rollout
Merge after kernel/kernel-images#364 is deployed so the documented punctuation form is supported by the runtime.

## Testing
- `make test`
- `make build`
- `./bin/kernel browsers computer press-key --help`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only README and CLI flag help text change; no execution or API behavior is modified.
> 
> **Overview**
> **Documentation-only** update for `kernel browsers computer press-key`: the `--key` flag is now described as one **X11 keysym or chord per value** (e.g. `Return`, `Ctrl+t`, `Ctrl+minus`), with the same wording in **README** and in **cobra `--help`** via `cmd/browsers.go`.
> 
> The README also adds guidance to pass **repeated or sequential** presses as multiple `--key` arguments and to use **`computer type --text`** for literal text instead of `press-key`. **No runtime or parsing behavior changes** in this PR; the PR notes pairing with a separate kernel-images deploy for the documented punctuation forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c31db1c6d7abc8b042c78391b82f2bf7b5e246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->