### PR TITLE
Add browser WebMCP list and invoke commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Commands with JSON output support:
 - **Apps**: `list`, `history`
 - **Deploy**: `deploy` (JSONL streaming), `history`
 - **Invoke**: `invoke` (JSONL streaming), `history`
-- **Browser Sub-commands**: `replays list/start`, `process exec/spawn`, `fs file-info/list-files`
+- **Browser Sub-commands**: `replays list/start`, `process exec/spawn`, `fs file-info/list-files`, `webmcp list` (`webmcp invoke` always prints JSON output)
 - **Browser NDJSON streaming**: `telemetry stream`
 
 ### Authentication
@@ -671,6 +671,26 @@ Destinations are the OTLP/HTTP endpoints sessions export to, managed per project
 - `kernel browsers playwright execute <id> [code]` - Execute Playwright/TypeScript code against the browser
   - `--timeout <seconds>` - Maximum execution time in seconds (defaults server-side)
   - If `[code]` is omitted, code is read from stdin
+
+### Browser WebMCP
+
+- `kernel browsers webmcp list <id-or-name>` - Discover native page tools across all browser tabs and embedded frames
+  - Displays name, opaque tool reference, page URL, tab ID, and read-only annotation (`-` when absent)
+  - `--json`, `--output json`, `-o json` - Output the raw response, including descriptions, input schemas, annotations, and source details
+- `kernel browsers webmcp invoke <id-or-name> --tool-ref <ref> --input '<json object>'` - Invoke the exact live tool registration
+  - `--tool-ref <ref>` - Opaque reference from `webmcp list` (required; do not reconstruct it from the tool name)
+  - `--input <json>` or `--input-file <path>` - Required JSON object; mutually exclusive. Use `--input-file -` to read stdin
+  - `--timeout-sec <seconds>` - Positive maximum execution time (defaults server-side)
+  - Prints the tool's `output` as pretty JSON on completion; tool errors and cancellations exit non-zero
+  - Invocations are never retried automatically. A 504 `outcome_unknown` error prints the code, invocation ID, and message and exits non-zero. The tool may already have had side effects; verify the outcome before invoking it again
+
+Tool references expire when their document or browser process is replaced. Annotations are untrusted page-provided hints, not enforced guarantees; tool output is also untrusted page-provided data.
+
+```bash
+kernel browsers webmcp list my-browser --json
+kernel browsers webmcp invoke my-browser --tool-ref '<tool_ref>' --input '{"query":"example"}' --timeout-sec 30
+kernel browsers webmcp invoke my-browser --tool-ref '<tool_ref>' --input-file input.json
+```
 
 ### Profiles
 

--- a/cmd/browsers.go
+++ b/cmd/browsers.go
@@ -436,6 +436,7 @@ type BrowsersCmd struct {
 	computer   BrowserComputerService
 	playwright BrowserPlaywrightService
 	telemetry  BrowserTelemetryService
+	webmcp     BrowserWebMCPService
 }
 
 type BrowsersListInput struct {
@@ -2950,6 +2951,7 @@ func init() {
 	addJSONOutputFlag(playwrightExecute)
 	playwrightRoot.AddCommand(playwrightExecute)
 	browsersCmd.AddCommand(playwrightRoot)
+	browsersCmd.AddCommand(newBrowsersWebMCPCommand())
 
 	// Add flags for create command
 	addJSONOutputFlag(browsersCreateCmd)

--- a/cmd/browsers_webmcp.go
+++ b/cmd/browsers_webmcp.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/kernel/cli/pkg/util"
+	kernel "github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/param"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+// BrowserWebMCPService defines the subset we use for native page tools.
+type BrowserWebMCPService interface {
+	ListTools(ctx context.Context, idOrName string, opts ...option.RequestOption) (*kernel.ToolsResponse, error)
+	InvokeTool(ctx context.Context, idOrName string, body kernel.BrowserWebmcpInvokeToolParams, opts ...option.RequestOption) (*kernel.InvocationResult, error)
+}
+
+type BrowsersWebMCPListInput struct {
+	Identifier string
+	Output     string
+}
+
+type BrowsersWebMCPInvokeInput struct {
+	Identifier string
+	ToolRef    string
+	Input      string
+	TimeoutSec param.Opt[int64]
+}
+
+func (b BrowsersCmd) WebMCPList(ctx context.Context, in BrowsersWebMCPListInput) error {
+	if err := validateJSONOutput(in.Output); err != nil {
+		return err
+	}
+	res, err := b.webmcp.ListTools(ctx, in.Identifier)
+	if err != nil {
+		return util.CleanedUpSdkError{Err: err}
+	}
+	if in.Output == "json" {
+		return util.PrintPrettyJSON(res)
+	}
+	if len(res.Tools) == 0 {
+		pterm.Info.Println("No WebMCP tools found")
+		return nil
+	}
+	rows := pterm.TableData{{"Name", "Tool Ref", "Page URL", "Tab ID", "Read Only"}}
+	for _, tool := range res.Tools {
+		readOnly := "-"
+		if tool.Annotations.JSON.ReadOnly.Valid() {
+			readOnly = strconv.FormatBool(tool.Annotations.ReadOnly)
+		}
+		rows = append(rows, []string{tool.Name, tool.ToolRef, tool.Source.PageURL, strconv.FormatInt(tool.Source.TabID, 10), readOnly})
+	}
+	PrintTableNoPad(rows, true)
+	return nil
+}
+
+func (b BrowsersCmd) WebMCPInvoke(ctx context.Context, in BrowsersWebMCPInvokeInput) error {
+	if strings.TrimSpace(in.ToolRef) == "" {
+		return fmt.Errorf("missing --tool-ref value")
+	}
+	if in.TimeoutSec.Valid() && in.TimeoutSec.Value <= 0 {
+		return fmt.Errorf("invalid --timeout-sec value: must be greater than zero")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(in.Input), &fields); err != nil {
+		return fmt.Errorf("invalid input: expected a JSON object: %w", err)
+	}
+	if fields == nil {
+		return fmt.Errorf("invalid input: expected a JSON object")
+	}
+	input := make(map[string]any, len(fields))
+	for key, value := range fields {
+		input[key] = value
+	}
+	params := kernel.BrowserWebmcpInvokeToolParams{InvokeRequest: kernel.InvokeRequestParam{
+		ToolRef: in.ToolRef, Input: input, TimeoutSec: in.TimeoutSec,
+	}}
+	// A lost response can hide completed side effects, so never retry an invocation.
+	res, err := b.webmcp.InvokeTool(ctx, in.Identifier, params, option.WithMaxRetries(0))
+	if err != nil {
+		return util.CleanedUpSdkError{Err: err}
+	}
+	if res.Status != kernel.InvocationResultStatusCompleted {
+		return fmt.Errorf("WebMCP invocation %s: %s: %s", res.InvocationID, res.Status, res.ErrorText)
+	}
+	// Preserve page-provided JSON numbers rather than re-encoding SDK float64 values.
+	var result struct {
+		Output json.RawMessage `json:"output"`
+	}
+	if err := json.Unmarshal([]byte(res.RawJSON()), &result); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(result.Output, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func newBrowsersWebMCPCommand() *cobra.Command {
+	root := &cobra.Command{Use: "webmcp", Short: "Discover and invoke native page tools"}
+	list := &cobra.Command{Use: "list <id-or-name>", Short: "List WebMCP tools across browser tabs and frames", Args: cobra.ExactArgs(1), RunE: runBrowsersWebMCPList}
+	addJSONOutputFlag(list)
+	list.Flags().Bool("json", false, "Output the raw API response as JSON (alias for --output json)")
+	invoke := &cobra.Command{Use: "invoke <id-or-name>", Short: "Invoke a WebMCP tool without automatic retries", Args: cobra.ExactArgs(1), RunE: runBrowsersWebMCPInvoke}
+	invoke.Flags().String("tool-ref", "", "Opaque tool reference from webmcp list")
+	_ = invoke.MarkFlagRequired("tool-ref")
+	invoke.Flags().String("input", "", "Tool input as a JSON object")
+	invoke.Flags().String("input-file", "", "Path to a JSON object file (use '-' for stdin)")
+	invoke.MarkFlagsOneRequired("input", "input-file")
+	invoke.MarkFlagsMutuallyExclusive("input", "input-file")
+	invoke.Flags().Int64("timeout-sec", 0, "Maximum execution time in seconds (default per server)")
+	root.AddCommand(list, invoke)
+	return root
+}
+
+func runBrowsersWebMCPList(cmd *cobra.Command, args []string) error {
+	output, _ := cmd.Flags().GetString("output")
+	if err := validateJSONOutput(output); err != nil {
+		return err
+	}
+	asJSON, _ := cmd.Flags().GetBool("json")
+	if asJSON {
+		output = "json"
+	}
+	client := getKernelClient(cmd)
+	b := BrowsersCmd{webmcp: &client.Browsers.Webmcp}
+	return b.WebMCPList(cmd.Context(), BrowsersWebMCPListInput{Identifier: args[0], Output: output})
+}
+
+func runBrowsersWebMCPInvoke(cmd *cobra.Command, args []string) error {
+	toolRef, _ := cmd.Flags().GetString("tool-ref")
+	input, _ := cmd.Flags().GetString("input")
+	if cmd.Flags().Changed("input-file") {
+		path, _ := cmd.Flags().GetString("input-file")
+		var data []byte
+		var err error
+		if path == "-" {
+			data, err = io.ReadAll(cmd.InOrStdin())
+		} else {
+			data, err = os.ReadFile(path)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read input file: %w", err)
+		}
+		input = string(data)
+	}
+	var timeout param.Opt[int64]
+	if cmd.Flags().Changed("timeout-sec") {
+		value, _ := cmd.Flags().GetInt64("timeout-sec")
+		timeout = kernel.Opt(value)
+	}
+	client := getKernelClient(cmd)
+	b := BrowsersCmd{webmcp: &client.Browsers.Webmcp}
+	return b.WebMCPInvoke(cmd.Context(), BrowsersWebMCPInvokeInput{Identifier: args[0], ToolRef: toolRef, Input: input, TimeoutSec: timeout})
+}

--- a/cmd/browsers_webmcp_test.go
+++ b/cmd/browsers_webmcp_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kernel/cli/pkg/util"
+	kernel "github.com/kernel/kernel-go-sdk"
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func executeWebMCPCommand(t *testing.T, handler http.HandlerFunc, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client := kernel.NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	root := &cobra.Command{Use: "kernel", SilenceErrors: true, SilenceUsage: true}
+	root.SetContext(context.WithValue(context.Background(), util.KernelClientKey, client))
+	root.SetIn(strings.NewReader(stdin))
+	root.AddCommand(newBrowsersWebMCPCommand())
+	root.SetArgs(append([]string{"webmcp"}, args...))
+	buf := capturePtermOutput(t)
+	var err error
+	stdout := captureStdout(t, func() { err = root.Execute() })
+	return stdout, buf.String(), err
+}
+
+const webMCPToolsFixture = `{"tools":[{"name":"search","tool_ref":"opaque/ref+==","description":"Search the page","input_schema":{"type":"object"},"annotations":{"read_only":true,"autosubmit":false,"consequential":false,"untrusted_content":true},"source":{"window_id":1,"tab_id":42,"page_url":"https://example.com","page_title":"Example","frame":null}}],"future_field":true}`
+
+func TestWebMCPCommandWiring(t *testing.T) {
+	for _, name := range []string{"list", "invoke"} {
+		cmd, remaining, err := rootCmd.Find([]string{"browsers", "webmcp", name})
+		require.NoError(t, err)
+		require.Empty(t, remaining)
+		assert.Equal(t, name, cmd.Name())
+		assert.NotNil(t, cmd.RunE)
+		assert.False(t, isAuthExempt(cmd))
+	}
+}
+
+func TestWebMCPList(t *testing.T) {
+	for _, identifier := range []string{"my-browser", "session123"} {
+		for _, flags := range [][]string{nil, {"--json"}, {"-o", "json"}, {"--output", "json"}} {
+			t.Run(identifier+strings.Join(flags, ""), func(t *testing.T) {
+				calls := 0
+				stdout, table, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					assert.Equal(t, http.MethodGet, r.Method)
+					assert.Equal(t, "/browsers/"+identifier+"/webmcp/tools", r.URL.Path)
+					w.Header().Set("Content-Type", "application/json")
+					fmt.Fprint(w, webMCPToolsFixture)
+				}, "", append([]string{"list", identifier}, flags...)...)
+				require.NoError(t, err)
+				assert.Equal(t, 1, calls)
+				if len(flags) > 0 {
+					assert.JSONEq(t, webMCPToolsFixture, stdout)
+					assert.Empty(t, table)
+				} else {
+					for _, value := range []string{"Name", "Tool Ref", "Page URL", "Tab ID", "Read Only", "search", "opaque/ref+==", "https://example.com", "42", "true"} {
+						assert.Contains(t, table, value)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestWebMCPListEmpty(t *testing.T) {
+	for _, flags := range [][]string{nil, {"--json"}} {
+		stdout, table, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"tools":[]}`)
+		}, "", append([]string{"list", "my-browser"}, flags...)...)
+		require.NoError(t, err)
+		if len(flags) == 0 {
+			assert.Contains(t, table, "No WebMCP tools found")
+		} else {
+			assert.JSONEq(t, `{"tools":[]}`, stdout)
+		}
+	}
+}
+
+func TestWebMCPListAnnotations(t *testing.T) {
+	for _, tc := range []struct{ annotation, want string }{
+		{`{"read_only":true}`, "true"},
+		{`{"read_only":false}`, "false"},
+		{`{}`, "-"},
+		{`null`, "-"},
+	} {
+		t.Run(tc.annotation, func(t *testing.T) {
+			_, table, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"tools":[{"name":"search","annotations":%s}]}`, tc.annotation)
+			}, "", "list", "my-browser")
+			require.NoError(t, err)
+			rows := strings.Split(strings.TrimSpace(table), "\n")
+			assert.True(t, strings.HasSuffix(strings.TrimSpace(rows[len(rows)-1]), tc.want), table)
+		})
+	}
+}
+
+func TestWebMCPInvoke(t *testing.T) {
+	input := `{"id":9007199254740993,"nested":{"items":[1,true,null]},"query":"example"}`
+	file := filepath.Join(t.TempDir(), "input.json")
+	require.NoError(t, os.WriteFile(file, []byte(input), 0600))
+	for _, tc := range []struct {
+		name, stdin string
+		flags       []string
+		timeout     bool
+	}{
+		{"inline", "", []string{"--input", input}, false},
+		{"file", "", []string{"--input-file", file, "--timeout-sec", "30"}, true},
+		{"stdin", input, []string{"--input-file", "-"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			stdout, table, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/browsers/my-browser/webmcp/invoke", r.URL.Path)
+				var body struct {
+					ToolRef string          `json:"tool_ref"`
+					Input   json.RawMessage `json:"input"`
+					Timeout *int64          `json:"timeout_sec"`
+				}
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				assert.Equal(t, "opaque/ref+==", body.ToolRef)
+				assert.JSONEq(t, input, string(body.Input))
+				assert.Contains(t, string(body.Input), "9007199254740993")
+				if tc.timeout {
+					require.NotNil(t, body.Timeout)
+					assert.Equal(t, int64(30), *body.Timeout)
+				} else {
+					assert.Nil(t, body.Timeout)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"invocation_id":"inv-1","status":"completed","output":{"id":9007199254740993,"ok":true}}`)
+			}, tc.stdin, append([]string{"invoke", "my-browser", "--tool-ref", "opaque/ref+=="}, tc.flags...)...)
+			require.NoError(t, err)
+			assert.Equal(t, 1, calls)
+			assert.Equal(t, "{\n  \"id\": 9007199254740993,\n  \"ok\": true\n}\n", stdout)
+			assert.Empty(t, table)
+		})
+	}
+}
+
+func TestWebMCPInvokeOutputTypes(t *testing.T) {
+	for _, output := range []string{`null`, `false`, `42`, `"text"`, `[]`, `{}`} {
+		t.Run(output, func(t *testing.T) {
+			stdout, _, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				data, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				assert.JSONEq(t, `{"tool_ref":"ref","input":{}}`, string(data))
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"invocation_id":"inv-1","status":"completed","output":%s}`, output)
+			}, "", "invoke", "session123", "--tool-ref", "ref", "--input", "{}")
+			require.NoError(t, err)
+			assert.JSONEq(t, output, stdout)
+		})
+	}
+}
+
+func TestWebMCPInvalidInput(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{[]string{"list"}, "accepts 1 arg"},
+		{[]string{"list", "browser", "extra"}, "accepts 1 arg"},
+		{[]string{"list", "browser", "--json", "-o", "yaml"}, "unsupported --output"},
+		{[]string{"invoke", "browser", "--input", "{}"}, "required flag"},
+		{[]string{"invoke", "browser", "--tool-ref", "ref"}, "at least one"},
+		{[]string{"invoke", "browser", "--tool-ref", "ref", "--input", "{}", "--input-file", "-"}, "none of the others can be"},
+		{[]string{"invoke", "browser", "--tool-ref=", "--input", "{}"}, "missing --tool-ref"},
+		{[]string{"invoke", "browser", "--tool-ref", "ref", "--input-file", filepath.Join(t.TempDir(), "missing")}, "failed to read input file"},
+		{[]string{"invoke", "browser", "--tool-ref", "ref", "--input-file", "-"}, "expected a JSON object"},
+	}
+	for _, input := range []string{"", "null", "[]", "1", "true", `"text"`, "{", "{} {}", "{} trailing"} {
+		tests = append(tests, struct {
+			args []string
+			want string
+		}{[]string{"invoke", "browser", "--tool-ref", "ref", "--input", input}, "invalid input"})
+	}
+	for _, timeout := range []string{"0", "-1"} {
+		tests = append(tests, struct {
+			args []string
+			want string
+		}{[]string{"invoke", "browser", "--tool-ref", "ref", "--input", "{}", "--timeout-sec", timeout}, "invalid --timeout-sec"})
+	}
+	for _, tc := range tests {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			_, _, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Error("invalid input reached API")
+			}, "", tc.args...)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestWebMCPInvokeNeverRetries(t *testing.T) {
+	for _, status := range []int{504, 500, 429} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			calls := 0
+			stdout, _, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Should-Retry", "true")
+				w.Header().Set("Retry-After", "0")
+				w.WriteHeader(status)
+				fmt.Fprint(w, `{"code":"outcome_unknown","invocation_id":"inv-unknown","message":"Tool may have completed"}`)
+			}, "", "invoke", "browser", "--tool-ref", "ref", "--input", "{}")
+			require.Error(t, err)
+			assert.Equal(t, 1, calls)
+			assert.Empty(t, stdout)
+			// The root error handler wraps command errors again before printing them.
+			assert.EqualError(t, util.CleanedUpSdkError{Err: err}, "outcome_unknown (invocation_id: inv-unknown): Tool may have completed")
+			var apiErr *kernel.Error
+			assert.ErrorAs(t, err, &apiErr)
+		})
+	}
+}
+
+func TestWebMCPInvokeFailedStatus(t *testing.T) {
+	for _, status := range []string{"error", "canceled"} {
+		t.Run(status, func(t *testing.T) {
+			stdout, _, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"invocation_id":"inv-1","status":%q,"error_text":"Tool did not complete"}`, status)
+			}, "", "invoke", "browser", "--tool-ref", "ref", "--input", "{}")
+			require.ErrorContains(t, err, "inv-1: "+status+": Tool did not complete")
+			assert.Empty(t, stdout)
+		})
+	}
+}
+
+func TestWebMCPListAPIError(t *testing.T) {
+	_, _, err := executeWebMCPCommand(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"code":"not_found","message":"Browser not found"}`)
+	}, "", "list", "missing")
+	require.EqualError(t, err, "not_found: Browser not found")
+}

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -24,6 +24,11 @@ func (e CleanedUpSdkError) Error() string {
 		if err := json.Unmarshal([]byte(kerror.RawJSON()), &m); err == nil {
 			message, _ := m["message"].(string)
 			code, _ := m["code"].(string)
+			if code == "outcome_unknown" {
+				if invocationID, _ := m["invocation_id"].(string); invocationID != "" {
+					return fmt.Sprintf("%s (invocation_id: %s): %s", code, invocationID, message)
+				}
+			}
 			return fmt.Sprintf("%s: %s", code, message)
 		} else if kerror.Response != nil && kerror.Response.Body != nil {
 			// try response body as text


### PR DESCRIPTION
## Summary
- Add `browsers webmcp list <id-or-name>` with a readable table and raw response output via `--json` or `-o json`.
- Add `browsers webmcp invoke` with a required opaque tool reference, JSON-object input from a flag/file/stdin, and an optional positive timeout. Preserve JSON numbers in input and output.
- Disable SDK retries for every invocation. Preserve the invocation ID when formatting `outcome_unknown` errors, and return non-zero for API errors, tool errors, and cancellations.
- Document commands, reference lifetime, and ambiguous outcomes. The repo already pins v0.100.0, confirmed as the latest published Go SDK release, so no dependency files changed.

## Validation
- `go test ./...`
- `go vet ./...`
- Built the CLI and exercised a local HTTP 504 response: one request, exit status 1, empty stdout, and code/invocation ID/message on stderr.
- Command tests cover wiring, ID/name paths, table/raw JSON output, annotations, input sources and validation, timeout serialization, output types, and no retries on 504/500/429 even with retry headers.